### PR TITLE
Only run on merged pull requests

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,8 +8,10 @@ jobs:
   build:
     name: Create backport PRs
     if: >
-      github.event_name == 'pull_request' ||
       (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged
+      ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '/backport')

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ jobs:
   build:
     name: Create backport PRs
     runs-on: ubuntu-latest
+    # don't run on closed unmerged pull requests
+    if: github.event.pull_request.merged
     steps:
       - uses: actions/checkout@v2
         with:
@@ -72,14 +74,16 @@ on:
 jobs:
   build:
     name: Create backport PRs
+    runs-on: ubuntu-latest
     if: >
-      github.event_name == 'pull_request' ||
       (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged
+      ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '/backport')
       )
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The pull_request [closed] event contains both merged and unmerged pull
requests. Since the bot now allows to trigger on comment, it has a build
in warning against being triggered for a unmerged pull request, but this
warning is also given when just closing a pull request.

This fixes this by further restricting when to trigger the action.

fixes #32 