### PR TITLE
Enable dependabot for gh-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This enables dependabot to manage versions of github actions used in this repo.

closes #24 