### PR TITLE
Cache npm dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/setup-node@v2.4.1
         with:
           node-version: 12.x
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Check formatting


### PR DESCRIPTION
We can now cache npm dependencies in the ci.