### PR TITLE
Permissions in examples

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Create backport PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # so it can comment
+      pull-requests: write # so it can create pull requests
     # Only run when pull request is merged
     # or when a comment containing `/backport` is created
     if: >

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ jobs:
   build:
     name: Create backport PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # so it can comment
+      pull-requests: write # so it can create pull requests
     # Don't run on closed unmerged pull requests
     if: github.event.pull_request.merged
     steps:
@@ -91,6 +94,9 @@ jobs:
   build:
     name: Create backport PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # so it can comment
+      pull-requests: write # so it can create pull requests
     # Only run when pull request is merged
     # or when a comment containing `/backport` is created
     if: >


### PR DESCRIPTION
GitHub recommends to set the GITHUB_TOKEN permissions to read-only by default. At the same time, our examples did not yet make it clear what permissions are required by this action.

We can simply add the permissions to the examples. This should make it clear what permissions are required, as well as resolve problems for users/repos with read-only defaults.

closes #189 