### PR TITLE
Let 

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -141,6 +141,7 @@ async function checkout(branch: string, start: string, pwd: string) {
 async function cherryPick(diffrefs: string[], pwd: string) {
   const { exitCode } = await git("cherry-pick", ["-x", ...diffrefs], pwd);
   if (exitCode !== 0) {
+    await git("cherry-pick", ["--abort"], pwd);
     throw new Error(
       `'git cherry-pick -x ${diffrefs}' failed with exit code ${exitCode}`
     );


### PR DESCRIPTION
When cherry-picking commits for one backport target fails, for example due to merge conflicts, the next backport will also fail because git is still in the cherry-picking state. When we abort the cherry-picking, the next backport might succeed which is a nice usability improvement.

Here is an example where this would have helped: https://github.com/camunda-cloud/zeebe/runs/4964915003?check_suite_focus=true

## Alternatives

We could also consider doing a `git reset` between every backport.