### PR TITLE
Workflow should not trigger on own comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ jobs:
       contents: write # so it can comment
       pull-requests: write # so it can create pull requests
     # Only run when pull request is merged
-    # or when a comment containing `/backport` is created by someone other than the backport-action
-    # bot user (user id: 97796249)
+    # or when a comment containing `/backport` is created by someone other than the 
+    # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
+    # own PAT as `github_token`, that you should replace this id with yours.
     if: >
       (
         github.event_name == 'pull_request' &&

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ jobs:
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        github.event.commend.user.id != 97796249 &&
+        github.event.comment.user.id != 97796249 &&
         contains(github.event.comment.body, '/backport')
       )
     steps:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ jobs:
       contents: write # so it can comment
       pull-requests: write # so it can create pull requests
     # Only run when pull request is merged
-    # or when a comment containing `/backport` is created
+    # or when a comment containing `/backport` is created by someone other than the backport-action
+    # bot user (user id: 97796249)
     if: >
       (
         github.event_name == 'pull_request' &&
@@ -106,6 +107,7 @@ jobs:
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
+        github.event.commend.user.id != 97796249 &&
         contains(github.event.comment.body, '/backport')
       )
     steps:


### PR DESCRIPTION
The backport-action bot added comments to PRs contain "/backport". This could result in the backport workflow being triggered again, causing an infinite loop of backport messages. By checking the user id of the comment we can prevent comments from backport-action triggering the workflow.