### PR TITLE
Support non-default `init.defaultbranch` git config

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -61,7 +61,7 @@ setup () {
     mkdir $REPOSITORY_NAME
     cd $REPOSITORY_NAME
 
-    git init
+    git init --initial-branch='master'
 
     echo "[commit]" >> .git/config
     echo "	gpgsign = false" >> .git/config


### PR DESCRIPTION
I was unable to run the acceptance tests anymore, after changing my global git config to use `main` as the default initial branch (`init.defaultbranch=main`).

Other users might also have specified a different branch.

We can solve this by being specific about the initial branch name