### PR TITLE
Default token and workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ jobs:
       - name: Create backport PRs
         uses: zeebe-io/backport-action@v0
         with:
-          # Required
+          # Optional
           # Token to authenticate requests to GitHub
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # github_token: ${{ secrets.GITHUB_TOKEN }}
 
-          # Required
+          # Optional
           # Working directory for the backport action
-          github_workspace: ${{ github.workspace }}
+          # github_workspace: ${{ github.workspace }}
 
           # Optional
           # Regex pattern to match github labels
@@ -123,13 +123,13 @@ jobs:
       - name: Create backport PRs
         uses: zeebe-io/backport-action@v0
         with:
-          # Required
+          # Optional
           # Token to authenticate requests to GitHub
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # github_token: ${{ secrets.GITHUB_TOKEN }}
 
-          # Required
+          # Optional
           # Working directory for the backport action
-          github_workspace: ${{ github.workspace }}
+          # github_workspace: ${{ github.workspace }}
 
           # Optional
           # Regex pattern to match github labels

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,8 @@ inputs:
       Either GITHUB_TOKEN or a repo-scoped Personal Access Token (PAT).
     default: ${{ github.token }}
   github_workspace:
-    description: The GitHub workspace directory path
-    required: true
+    description: Working directory for the backport action.
+    default: ${{ github.workspace }}
   label_pattern:
     description: A regex pattern to match the backport labels.
     default: ^backport ([^ ]+)$

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,10 @@ description: "Automatically backport pull requests"
 author: "zeebe-io"
 inputs:
   github_token:
-    description: Token for the GitHub API
-    required: true
+    description: >
+      Token to authenticate requests to GitHub.
+      Either GITHUB_TOKEN or a repo-scoped Personal Access Token (PAT).
+    default: ${{ github.token }}
   github_workspace:
     description: The GitHub workspace directory path
     required: true

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,7 @@ inputs:
     description: The GitHub workspace directory path
     required: true
   label_pattern:
-    description: A regex pattern to match the backport labels
-    required: false
+    description: A regex pattern to match the backport labels.
     default: ^backport ([^ ]+)$
   pull_description:
     description: >
@@ -18,7 +17,6 @@ inputs:
       Placeholders can be used to define variable values.
       These are indicated by a dollar sign and curly braces (`${placeholder}`).
       Please refer to this action's README for all available placeholders.
-    required: false
     default: |-
       # Description
       Backport of #${pull_number} to `${target_branch}`.
@@ -28,7 +26,6 @@ inputs:
       Placeholders can be used to define variable values.
       These are indicated by a dollar sign and curly braces (`${placeholder}`).
       Please refer to this action's README for all available placeholders.
-    required: false
     default: >-
       [Backport ${target_branch}] ${pull_title}
 


### PR DESCRIPTION
The inputs `github_token` and `github_workspace` have historically been required. However, we can provide defaults for them using variable expansion for their definition in `action.yml`.