### PR TITLE
Remove deprecated version input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,11 +31,6 @@ inputs:
     required: false
     default: >-
       [Backport ${target_branch}] ${pull_title}
-
-  # DEPRECATED
-  version:
-    description: The version of backport-action - deprecated
-    required: false
 runs:
   using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
As we're now moving to v1, we can break backward compatibility once. It's a good opportunity to remove the deprecated `version` input. Which hasn't been in use for over a year.