### PR TITLE
Add experimental Backport Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ on:
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
+  issues: write # so it can create the dashboard issue
 jobs:
   backport:
     name: Backport pull request
@@ -75,6 +76,7 @@ on:
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
+  issues: write # so it can create the dashboard issue
 jobs:
   backport:
     name: Backport pull request

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ on:
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
-  issues: write # so it can create the dashboard issue
 jobs:
   backport:
     name: Backport pull request
@@ -76,7 +75,6 @@ on:
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
-  issues: write # so it can create the dashboard issue
 jobs:
   backport:
     name: Backport pull request
@@ -294,6 +292,16 @@ When set to `true`, the action will maintain a "Backport Dashboard" issue in the
 This issue tracks the status of all backport pull requests created by the action.
 It lists the original PRs and their backports.
 On subsequent runs, it removes items from the list for which all backports are merged or closed.
+
+> [!Note]
+> This feature requires the `issues: write` permission to create and update the dashboard issue.
+>
+> ```yaml
+> permissions:
+>   contents: write
+>   pull-requests: write
+>   issues: write # Required for dashboard
+> ```
 
 > [!Note]
 > To prevent race conditions when running the action with `dashboard_enabled`, 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ Default:
 
 ```json
 {
-  "detect_merge_method": false
+  "conflict_resolution": "fail",
+  "dashboard_enabled": false
 }
 ```
 
@@ -284,6 +285,26 @@ Behavior is defined by the option selected.
 - When set to `draft_commit_conflicts` the backport will always create a draft pull request with the first conflict encountered committed.
 
 Instructions are provided on the original pull request on how to resolve the conflict and continue the cherry-pick.
+
+#### `dashboard_enabled`
+
+Default: `false`
+
+When set to `true`, the action will maintain a "Backport Dashboard" issue in the repository.
+This issue tracks the status of all backport pull requests created by the action.
+It lists the original PRs and their backports.
+On subsequent runs, it removes items from the list for which all backports are merged or closed.
+
+> [!Note]
+> To prevent race conditions when running the action with `dashboard_enabled`, 
+> it is recommended to use the `concurrency` feature of GitHub Actions.
+> Add the following to your job configuration:
+>
+> ```yaml
+> concurrency:
+>   group: backport-dashboard
+>   cancel-in-progress: false
+> ```
 
 #### `downstream_repo`
 

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,15 @@ inputs:
 
       Instructions are provided on the original pull request on how to resolve the conflict and continue the cherry-pick.
 
+      #### `dashboard_enabled`
+
+      When set to `true`, the action will maintain a "Backport Dashboard" issue in the repository.
+      This issue tracks the status of all backport pull requests created by the action.
+      It lists the original PRs and their backports.
+      On subsequent runs, it removes items from the list for which all backports are merged or closed.
+
+      By default, the dashboard is disabled.
+
       #### `downstream_repo`
 
       Define if you want to backport to a repository other than where the workflow runs.
@@ -95,16 +104,10 @@ inputs:
       Only takes effect if the `downstream_repo` property is also defined.
 
       By default, uses the owner of the repository in which the workflow runs.
-
-      #### `dashboard_enabled`
-
-      Define if you want to enable the Backport Dashboard.
-      The dashboard is a single issue that tracks the status of backport pull requests.
-
-      By default, the dashboard is disabled.
     default: >
       {
-        "conflict_resolution": "fail"
+        "conflict_resolution": "fail",
+        "dashboard_enabled": false
       }
   github_token:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,13 @@ inputs:
       Only takes effect if the `downstream_repo` property is also defined.
 
       By default, uses the owner of the repository in which the workflow runs.
+
+      #### `dashboard_enabled`
+
+      Define if you want to enable the Backport Dashboard.
+      The dashboard is a single issue that tracks the status of backport pull requests.
+
+      By default, the dashboard is disabled.
     default: >
       {
         "conflict_resolution": "fail"

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,8 @@ inputs:
       It lists the original PRs and their backports.
       On subsequent runs, it removes items from the list for which all backports are merged or closed.
 
+      **Note:** This feature requires the `issues: write` permission to create and update the dashboard issue.
+
       By default, the dashboard is disabled.
 
       #### `downstream_repo`

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -80,11 +80,17 @@ export class Backport {
     this.github = github;
     this.config = config;
     this.git = git;
-    this.dashboard = new Dashboard(github);
 
     this.downstreamRepo = this.config.experimental.downstream_repo ?? undefined;
     this.downstreamOwner =
       this.config.experimental.downstream_owner ?? undefined;
+
+    const owner =
+      this.shouldUseDownstreamRepo() && this.downstreamOwner
+        ? this.downstreamOwner
+        : this.github.getRepo().owner;
+
+    this.dashboard = new Dashboard(github, owner, this.downstreamRepo);
   }
 
   shouldUseDownstreamRepo(): boolean {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -27,8 +27,17 @@ export class Dashboard {
     ---
     `;
 
-  constructor(github: GithubApi) {
+  private downstreamOwner?: string;
+  private downstreamRepo?: string;
+
+  constructor(
+    github: GithubApi,
+    downstreamOwner?: string,
+    downstreamRepo?: string,
+  ) {
     this.github = github;
+    this.downstreamOwner = downstreamOwner;
+    this.downstreamRepo = downstreamRepo;
   }
 
   public async createOrUpdateDashboard(
@@ -157,7 +166,9 @@ export class Dashboard {
 
     const sectionRegex = /^## #(\d+) (.*)$/;
     const itemRegex =
-      version === 0 ? /^- `(.*)`: #(\d+) (.*)$/ : /^- `(.*)`: #(\d+)$/;
+      version === 0
+        ? /^- `(.*)`: (?:[^/]+\/[^/]+)?#(\d+) (.*)$/
+        : /^- `(.*)`: (?:[^/]+\/[^/]+)?#(\d+)$/;
 
     for (const line of lines) {
       const sectionMatch = line.match(sectionRegex);
@@ -187,7 +198,11 @@ export class Dashboard {
     for (const entry of entries) {
       body += `\n## #${entry.originalPrNumber} ${entry.originalPrTitle}\n`;
       for (const bpr of entry.backports) {
-        body += `- \`${bpr.branch}\`: #${bpr.number}\n`;
+        const link =
+          this.downstreamOwner && this.downstreamRepo
+            ? `${this.downstreamOwner}/${this.downstreamRepo}#${bpr.number}`
+            : `#${bpr.number}`;
+        body += `- \`${bpr.branch}\`: ${link}\n`;
       }
     }
     return body;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -134,7 +134,10 @@ export class Dashboard {
   }
 
   private async findDashboardIssue(): Promise<Issue | undefined> {
-    const issues = await this.github.getIssues(Dashboard.TITLE);
+    const issues = await this.github.getIssues(Dashboard.TITLE, [
+      "is:open",
+      "sort:created-asc",
+    ]);
     // Filter by exact title match to be safe
     return issues.find((i) => i.title === Dashboard.TITLE);
   }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -77,11 +77,11 @@ export class Dashboard {
     const activeBackports: BackportEntry[] = [];
     for (const bpr of prEntry.backports) {
       const pr = await this.github.getPullRequest(bpr.number);
-      if (!(await this.github.isMerged(pr))) {
+      if (pr.state === "open") {
         console.log(`Backport #${bpr.number} is still pending`);
         activeBackports.push(bpr);
       } else {
-        console.log(`Backport #${bpr.number} is merged`);
+        console.log(`Backport #${bpr.number} is closed or merged`);
       }
     }
     prEntry.backports = activeBackports;
@@ -89,7 +89,7 @@ export class Dashboard {
     // If no backports left, remove the entry
     if (prEntry.backports.length === 0) {
       console.log(
-        `All backports for #${originalPR.number} are merged, removing entry`,
+        `All backports for #${originalPR.number} are closed or merged, removing entry`,
       );
       const index = entries.indexOf(prEntry);
       if (index > -1) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -100,16 +100,29 @@ export class Dashboard {
     // Reconstruct body
     const newBody = this.renderDashboard(entries);
 
-    if (issue) {
-      if (issue.body !== newBody) {
-        console.info(`Updating dashboard issue #${issue.number}`);
-        await this.github.updateIssue(issue.number, newBody);
+    try {
+      if (issue) {
+        if (issue.body !== newBody) {
+          console.info(`Updating dashboard issue #${issue.number}`);
+          await this.github.updateIssue(issue.number, newBody);
+        } else {
+          console.log(`Dashboard issue #${issue.number} is up to date`);
+        }
       } else {
-        console.log(`Dashboard issue #${issue.number} is up to date`);
+        console.info("Creating new dashboard issue");
+        await this.github.createIssue(Dashboard.TITLE, newBody);
       }
-    } else {
-      console.info("Creating new dashboard issue");
-      await this.github.createIssue(Dashboard.TITLE, newBody);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Resource not accessible by integration")
+      ) {
+        console.error(
+          "Failed to create or update the dashboard issue. " +
+            "Please ensure that the 'issues: write' permission is enabled in your workflow.",
+        );
+      }
+      throw error;
     }
   }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -22,7 +22,15 @@ export class Dashboard {
     The action automatically adds newly created backports. \
     Pull requests where all backports are merged or closed are \
     automatically removed from this list on subsequent runs. \
-    This allows maintainers to keep track of backports that still need attention.
+    This allows maintainers to keep track of backports that still need \
+    attention.
+
+    > [!NOTE]
+    > Please do not edit this issue manually unless you need to resolve \
+    any issues. The action uses the issue as a data store. Additionally, \
+    please note that this dashboard is an experimental feature. If you \
+    notice any mistakes or problems, please report them in \
+    [the action's repo](https://github.com/korthout/backport-action/issues).
     
     ---
     `;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -101,27 +101,32 @@ export class Dashboard {
 
     // Find or create entry for originalPR
     let prEntry = entries.find((e) => e.originalPrNumber === originalPR.number);
-    if (!prEntry) {
-      prEntry = {
-        originalPrNumber: originalPR.number,
-        originalPrTitle: originalPR.title,
-        backports: [],
-      };
-      entries.push(prEntry);
-    }
 
-    // Add new backports
-    for (const bpr of backportPRs) {
-      if (
-        !prEntry.backports.some((existing) => existing.number === bpr.number)
-      ) {
-        console.log(
-          `Tracking backport #${bpr.number} for original PR #${originalPR.number}`,
-        );
-        prEntry.backports.push({
-          number: bpr.number,
-          branch: bpr.base.ref,
-        });
+    if (backportPRs.length <= 0) {
+      console.log(`No new backports to add for #${originalPR.number}`);
+    } else {
+      if (!prEntry) {
+        prEntry = {
+          originalPrNumber: originalPR.number,
+          originalPrTitle: originalPR.title,
+          backports: [],
+        };
+        entries.push(prEntry);
+      }
+
+      // Add new backports
+      for (const bpr of backportPRs) {
+        if (
+          !prEntry.backports.some((existing) => existing.number === bpr.number)
+        ) {
+          console.log(
+            `Tracking backport #${bpr.number} for original PR #${originalPR.number}`,
+          );
+          prEntry.backports.push({
+            number: bpr.number,
+            branch: bpr.base.ref,
+          });
+        }
       }
     }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -264,6 +264,12 @@ export class Dashboard {
 
   private renderDashboard(entries: DashboardEntry[]): string {
     let body = Dashboard.HEADER;
+
+    if (entries.length === 0) {
+      body += "\nNo active backports.\n";
+      return body;
+    }
+
     for (const entry of entries) {
       const sanitizedTitle = entry.originalPrTitle.replace(/\n/g, " ");
       body += `\n## #${entry.originalPrNumber} ${sanitizedTitle}\n`;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -16,7 +16,7 @@ export class Dashboard {
   private github: GithubApi;
   private static readonly TITLE = "Backport Dashboard";
   private static readonly HEADER = dedent`\
-    <!-- VERSION: 1 -->\
+    <!-- VERSION: 1 -->
     This issue lists pull requests that have been backported by \
     [backport-action](https://github.com/korthout/backport-action). \
     The action automatically adds newly created backports. \

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -16,9 +16,16 @@ type DashboardEntry = {
 export class Dashboard {
   private github: GithubApi;
   private static readonly TITLE = "Backport Dashboard";
-  private static readonly HEADER = dedent`# ${Dashboard.TITLE}
-
-    This issue lists pull requests that have been backported by [backport-action](https://github.com/korthout/backport-action) that have not been merged yet.`;
+  private static readonly HEADER = dedent`\
+    This issue lists pull requests that have been backported by \
+    [backport-action](https://github.com/korthout/backport-action). \
+    The action automatically adds newly created backports. \
+    Pull requests where all backports are merged or closed are \
+    automatically removed from this list on subsequent runs. \
+    This allows maintainers to keep track of backports that still need attention.
+    
+    ---
+    `;
 
   constructor(github: GithubApi) {
     this.github = github;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -84,9 +84,7 @@ export class Dashboard {
         await this.github.updateIssue(issue.number, newBody);
       }
     } else {
-      if (entries.length > 0) {
-        await this.github.createIssue(Dashboard.TITLE, newBody);
-      }
+      await this.github.createIssue(Dashboard.TITLE, newBody);
     }
   }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -252,6 +252,7 @@ export class Dashboard {
         if (!numberMatch) continue;
 
         const number = parseInt(numberMatch[1], 10);
+        if (Number.isNaN(number)) continue;
 
         currentEntry.backports.push({
           branch,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -80,14 +80,22 @@ export class Dashboard {
       const activeBackports: BackportEntry[] = [];
 
       for (const bpr of entry.backports) {
-        const pr = await this.github.getPullRequest(bpr.number);
-        if (pr.state === "open") {
-          activeBackports.push(bpr);
-          console.log(
-            `Original PR #${entry.originalPrNumber} still has active backports, keeping it in the dashboard`,
+        try {
+          const pr = await this.github.getPullRequest(bpr.number);
+          if (pr.state === "open") {
+            activeBackports.push(bpr);
+            console.log(
+              `Original PR #${entry.originalPrNumber} still has active backports, keeping it in the dashboard`,
+            );
+          } else {
+            console.log(`Backport #${bpr.number} is closed or merged`);
+          }
+        } catch (error) {
+          console.error(
+            `Failed to fetch backport #${bpr.number} for original PR #${entry.originalPrNumber}. Treating it as still active.`,
+            error,
           );
-        } else {
-          console.log(`Backport #${bpr.number} is closed or merged`);
+          activeBackports.push(bpr);
         }
       }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -257,13 +257,17 @@ export class Dashboard {
   private renderDashboard(entries: DashboardEntry[]): string {
     let body = Dashboard.HEADER;
     for (const entry of entries) {
-      body += `\n## #${entry.originalPrNumber} ${entry.originalPrTitle}\n`;
+      const sanitizedTitle = entry.originalPrTitle.replace(/\n/g, " ");
+      body += `\n## #${entry.originalPrNumber} ${sanitizedTitle}\n`;
       for (const bpr of entry.backports) {
+        const sanitizedBranch = bpr.branch.replace(/(\\)?`/g, (match, p1) => {
+          return p1 ? match : "\\`";
+        });
         const link =
           this.downstreamOwner && this.downstreamRepo
             ? `${this.downstreamOwner}/${this.downstreamRepo}#${bpr.number}`
             : `#${bpr.number}`;
-        body += `- \`${bpr.branch}\`: ${link}\n`;
+        body += `- \`${sanitizedBranch}\`: ${link}\n`;
       }
     }
     return body;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,141 @@
+import dedent from "dedent";
+import { GithubApi, PullRequest, Issue } from "./github";
+
+type BackportEntry = {
+  number: number;
+  branch: string;
+  title: string;
+};
+
+type DashboardEntry = {
+  originalPrNumber: number;
+  originalPrTitle: string;
+  backports: BackportEntry[];
+};
+
+export class Dashboard {
+  private github: GithubApi;
+  private static readonly TITLE = "Backport Dashboard";
+  private static readonly HEADER = dedent`# ${Dashboard.TITLE}
+
+    This issue lists pull requests that have been backported by [backport-action](https://github.com/korthout/backport-action) that have not been merged yet.`;
+
+  constructor(github: GithubApi) {
+    this.github = github;
+  }
+
+  public async createOrUpdateDashboard(
+    originalPR: PullRequest,
+    backportPRs: { number: number; html_url: string; base: { ref: string } }[],
+  ): Promise<void> {
+    const issue = await this.findDashboardIssue();
+    let body = issue ? (issue.body ?? "") : Dashboard.HEADER;
+
+    // Parse existing body
+    const entries = this.parseDashboard(body);
+
+    // Find or create entry for originalPR
+    let prEntry = entries.find((e) => e.originalPrNumber === originalPR.number);
+    if (!prEntry) {
+      prEntry = {
+        originalPrNumber: originalPR.number,
+        originalPrTitle: originalPR.title,
+        backports: [],
+      };
+      entries.push(prEntry);
+    }
+
+    // Add new backports
+    for (const bpr of backportPRs) {
+      if (
+        !prEntry.backports.some((existing) => existing.number === bpr.number)
+      ) {
+        prEntry.backports.push({
+          number: bpr.number,
+          branch: bpr.base.ref,
+          title: originalPR.title,
+        });
+      }
+    }
+
+    // Check status of all backports in this entry
+    const activeBackports: BackportEntry[] = [];
+    for (const bpr of prEntry.backports) {
+      const pr = await this.github.getPullRequest(bpr.number);
+      if (!(await this.github.isMerged(pr))) {
+        activeBackports.push(bpr);
+      }
+    }
+    prEntry.backports = activeBackports;
+
+    // If no backports left, remove the entry
+    if (prEntry.backports.length === 0) {
+      const index = entries.indexOf(prEntry);
+      if (index > -1) {
+        entries.splice(index, 1);
+      }
+    }
+
+    // Reconstruct body
+    const newBody = this.renderDashboard(entries);
+
+    if (issue) {
+      if (issue.body !== newBody) {
+        await this.github.updateIssue(issue.number, newBody);
+      }
+    } else {
+      if (entries.length > 0) {
+        await this.github.createIssue(Dashboard.TITLE, newBody);
+      }
+    }
+  }
+
+  private async findDashboardIssue(): Promise<Issue | undefined> {
+    const issues = await this.github.getIssues(Dashboard.TITLE);
+    // Filter by exact title match to be safe
+    return issues.find((i) => i.title === Dashboard.TITLE);
+  }
+
+  private parseDashboard(body: string): DashboardEntry[] {
+    const entries: DashboardEntry[] = [];
+    const lines = body.split("\n");
+    let currentEntry: DashboardEntry | null = null;
+
+    const sectionRegex = /^## #(\d+) (.*)$/;
+    const itemRegex = /^- `(.*)`: #(\d+) (.*)$/;
+
+    for (const line of lines) {
+      const sectionMatch = line.match(sectionRegex);
+      if (sectionMatch) {
+        currentEntry = {
+          originalPrNumber: parseInt(sectionMatch[1], 10),
+          originalPrTitle: sectionMatch[2],
+          backports: [],
+        };
+        entries.push(currentEntry);
+        continue;
+      }
+
+      const itemMatch = line.match(itemRegex);
+      if (itemMatch && currentEntry) {
+        currentEntry.backports.push({
+          branch: itemMatch[1],
+          number: parseInt(itemMatch[2], 10),
+          title: itemMatch[3],
+        });
+      }
+    }
+    return entries;
+  }
+
+  private renderDashboard(entries: DashboardEntry[]): string {
+    let body = Dashboard.HEADER;
+    for (const entry of entries) {
+      body += `\n## #${entry.originalPrNumber} ${entry.originalPrTitle}\n`;
+      for (const bpr of entry.backports) {
+        body += `- \`${bpr.branch}\`: #${bpr.number} ${bpr.title}\n`;
+      }
+    }
+    return body;
+  }
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -445,6 +445,7 @@ export type PullRequest = {
   number: number;
   title: string;
   body: string | null;
+  state: string;
   merge_commit_sha: string | null;
   head: {
     sha: string;

--- a/src/github.ts
+++ b/src/github.ts
@@ -41,6 +41,9 @@ export interface GithubApi {
     merge_commit_sha: string | null,
   ): Promise<string | null>;
   getMergeCommitSha(pull: PullRequest): Promise<string | null>;
+  getIssues(title: string): Promise<Issue[]>;
+  createIssue(title: string, body: string): Promise<Issue>;
+  updateIssue(number: number, body: string): Promise<void>;
 }
 
 export class Github implements GithubApi {
@@ -389,6 +392,35 @@ export class Github implements GithubApi {
 
     return MergeStrategy.UNKNOWN;
   }
+
+  public async getIssues(title: string) {
+    console.log(`Retrieve issues with title ${title}`);
+    return this.#octokit.rest.search
+      .issuesAndPullRequests({
+        q: `repo:${this.getRepo().owner}/${this.getRepo().repo} is:issue is:open in:title ${title}`,
+      })
+      .then((res) => res.data.items as Issue[]);
+  }
+
+  public async createIssue(title: string, body: string) {
+    console.log(`Create issue ${title}`);
+    return this.#octokit.rest.issues
+      .create({
+        ...this.getRepo(),
+        title,
+        body,
+      })
+      .then((res) => res.data as Issue);
+  }
+
+  public async updateIssue(number: number, body: string) {
+    console.log(`Update issue ${number}`);
+    await this.#octokit.rest.issues.update({
+      ...this.getRepo(),
+      issue_number: number,
+      body,
+    });
+  }
 }
 
 export enum MergeStrategy {
@@ -397,6 +429,12 @@ export enum MergeStrategy {
   MERGECOMMIT = "mergecommit",
   UNKNOWN = "unknown",
 }
+
+export type Issue = {
+  number: number;
+  title: string;
+  body: string | null;
+};
 
 export type Repo = {
   owner: string;
@@ -414,7 +452,9 @@ export type PullRequest = {
   };
   base: {
     sha: string;
+    ref: string;
   };
+  html_url: string;
   user: {
     login: string;
   };
@@ -442,6 +482,10 @@ export type CreatePullRequestResponse = {
   status: number;
   data: {
     number: number;
+    html_url: string;
+    base: {
+      ref: string;
+    };
     requested_reviewers?: ({ login: string } | null)[] | null;
   };
 };

--- a/src/github.ts
+++ b/src/github.ts
@@ -41,7 +41,7 @@ export interface GithubApi {
     merge_commit_sha: string | null,
   ): Promise<string | null>;
   getMergeCommitSha(pull: PullRequest): Promise<string | null>;
-  getIssues(title: string): Promise<Issue[]>;
+  getIssues(title: string, options: string[]): Promise<Issue[]>;
   createIssue(title: string, body: string): Promise<Issue>;
   updateIssue(number: number, body: string): Promise<void>;
 }
@@ -393,11 +393,11 @@ export class Github implements GithubApi {
     return MergeStrategy.UNKNOWN;
   }
 
-  public async getIssues(title: string) {
+  public async getIssues(title: string, options: string[] = []) {
     console.log(`Retrieve issues with title ${title}`);
     return this.#octokit.rest.search
       .issuesAndPullRequests({
-        q: `repo:${this.getRepo().owner}/${this.getRepo().repo} is:issue is:open in:title ${title}`,
+        q: `repo:${this.getRepo().owner}/${this.getRepo().repo} is:issue in:title ${title} ${options.join(" ")}`,
       })
       .then((res) => res.data.items as Issue[]);
   }

--- a/src/test/dashboard.test.ts
+++ b/src/test/dashboard.test.ts
@@ -238,4 +238,19 @@ describe("Dashboard", () => {
       );
     });
   });
+
+  it("does not create an entry if no backports are provided", async () => {
+    mockGithubApi.getIssues.mockResolvedValue([]);
+
+    await dashboard.createOrUpdateDashboard(originalPR, []);
+
+    expect(mockGithubApi.createIssue).toHaveBeenCalledWith(
+      "Backport Dashboard",
+      expect.stringContaining("No active backports."),
+    );
+    expect(mockGithubApi.createIssue).not.toHaveBeenCalledWith(
+      "Backport Dashboard",
+      expect.stringContaining("## #123 My bug fix"),
+    );
+  });
 });

--- a/src/test/dashboard.test.ts
+++ b/src/test/dashboard.test.ts
@@ -126,7 +126,7 @@ describe("Dashboard", () => {
     expect(updatedBody).toContain("- `branch/y`: #125");
   });
 
-  it("handles version 0 dashboard format", async () => {
+  it("does not update on unsupported dashboard version", async () => {
     mockGithubApi.getIssues.mockResolvedValue([
       {
         number: 1,
@@ -145,14 +145,7 @@ describe("Dashboard", () => {
 
     await dashboard.createOrUpdateDashboard(originalPR, [backportPR]);
 
-    const [issueNumber, updatedBody] = mockGithubApi.updateIssue.mock.lastCall;
-    expect(issueNumber).toBe(1);
-    // Should update to new format (VERSION 1)
-    expect(updatedBody).toContain("<!-- VERSION: 1 -->");
-
-    // Should keep the old entry but formatted correctly (without title in list item)
-    expect(updatedBody).toContain("- `branch/old`: #101");
-    expect(updatedBody).not.toContain("- `branch/old`: #101 Old PR");
+    expect(mockGithubApi.updateIssue).not.toHaveBeenCalled();
   });
 
   describe("when downstream repo is configured", () => {

--- a/src/test/dashboard.test.ts
+++ b/src/test/dashboard.test.ts
@@ -1,0 +1,157 @@
+import { Dashboard } from "../dashboard";
+import { GithubApi, PullRequest } from "../github";
+import dedent from "dedent";
+
+const mockGithubApi = {
+  getIssues: jest.fn(),
+  createIssue: jest.fn(),
+  updateIssue: jest.fn(),
+  getPullRequest: jest.fn(),
+};
+
+describe("Dashboard", () => {
+  let dashboard: Dashboard;
+
+  beforeEach(() => {
+    dashboard = new Dashboard(mockGithubApi as unknown as GithubApi);
+    jest.clearAllMocks();
+  });
+
+  const originalPR = {
+    number: 123,
+    title: "My bug fix",
+  } as PullRequest;
+
+  const backportPR = {
+    number: 124,
+    html_url: "http://github.com/owner/repo/pull/124",
+    base: { ref: "branch/x" },
+  };
+
+  it("creates a new dashboard with a new entry", async () => {
+    mockGithubApi.getIssues.mockResolvedValue([]);
+
+    await dashboard.createOrUpdateDashboard(originalPR, [backportPR]);
+
+    expect(mockGithubApi.createIssue).toHaveBeenCalledWith(
+      "Backport Dashboard",
+      expect.stringMatching(/## #123 My bug fix\n- `branch\/x`: #124/),
+    );
+  });
+
+  it("removes older entries that are completed", async () => {
+    mockGithubApi.getIssues.mockResolvedValue([
+      {
+        number: 1,
+        title: "Backport Dashboard",
+        body: dedent`<!-- VERSION: 1 -->
+          This issue lists pull requests...
+
+          ## #100 Old PR
+          - \`branch/old\`: #101`,
+      },
+    ]);
+
+    mockGithubApi.getPullRequest.mockResolvedValue({
+      number: 101,
+      state: "closed",
+    });
+
+    await dashboard.createOrUpdateDashboard(originalPR, [backportPR]);
+
+    expect(mockGithubApi.updateIssue).toHaveBeenCalledWith(
+      1,
+      expect.not.stringContaining("## #100 Old PR"),
+    );
+  });
+
+  it("keeps older entries that are still pending", async () => {
+    mockGithubApi.getIssues.mockResolvedValue([
+      {
+        number: 1,
+        title: "Backport Dashboard",
+        body: dedent`<!-- VERSION: 1 -->
+          This issue lists pull requests...
+
+          ## #100 Old PR
+          - \`branch/old\`: #101`,
+      },
+    ]);
+
+    mockGithubApi.getPullRequest.mockResolvedValue({
+      number: 101,
+      state: "open",
+    });
+
+    await dashboard.createOrUpdateDashboard(originalPR, [backportPR]);
+
+    const [issueNumber, updatedBody] = mockGithubApi.updateIssue.mock.lastCall;
+    expect(issueNumber).toBe(1);
+    expect(updatedBody).toContain("## #100 Old PR");
+    expect(updatedBody).toContain("## #123 My bug fix");
+  });
+
+  it("adds new backports to existing entries", async () => {
+    mockGithubApi.getIssues.mockResolvedValue([
+      {
+        number: 1,
+        title: "Backport Dashboard",
+        body: dedent`<!-- VERSION: 1 -->
+          This issue lists pull requests...
+
+          ## #123 My bug fix
+          - \`branch/x\`: #124`,
+      },
+    ]);
+
+    mockGithubApi.getPullRequest.mockResolvedValue({
+      number: 124,
+      state: "open",
+    });
+
+    const newBackportPR = {
+      number: 125,
+      html_url: "http://github.com/owner/repo/pull/125",
+      base: { ref: "branch/y" },
+    };
+
+    await dashboard.createOrUpdateDashboard(originalPR, [
+      backportPR,
+      newBackportPR,
+    ]);
+
+    const [issueNumber, updatedBody] = mockGithubApi.updateIssue.mock.lastCall;
+    expect(issueNumber).toBe(1);
+    expect(updatedBody).toContain("- `branch/x`: #124");
+    expect(updatedBody).toContain("- `branch/y`: #125");
+  });
+
+  it("handles version 0 dashboard format", async () => {
+    mockGithubApi.getIssues.mockResolvedValue([
+      {
+        number: 1,
+        title: "Backport Dashboard",
+        body: dedent`This issue lists pull requests...
+
+          ## #100 Old PR
+          - \`branch/old\`: #101 Old PR`,
+      },
+    ]);
+
+    mockGithubApi.getPullRequest.mockResolvedValue({
+      number: 101,
+      state: "open",
+    });
+
+    await dashboard.createOrUpdateDashboard(originalPR, [backportPR]);
+
+    const [issueNumber, updatedBody] = mockGithubApi.updateIssue.mock.lastCall;
+    expect(issueNumber).toBe(1);
+    // Should update to new format (VERSION 1)
+    expect(updatedBody).toContain("<!-- VERSION: 1 -->");
+
+    // Should keep the old entry but formatted correctly (without title in list item)
+    expect(updatedBody).toContain("- `branch/old`: #101");
+    expect(updatedBody).not.toContain("- `branch/old`: #101 Old PR");
+  });
+});

--- a/src/test/dashboard_parsing.test.ts
+++ b/src/test/dashboard_parsing.test.ts
@@ -1,0 +1,149 @@
+import { Dashboard } from "../dashboard";
+import { GithubApi } from "../github";
+import dedent from "dedent";
+
+// Expose private method for testing
+class TestableDashboard extends Dashboard {
+  public parseDashboardPublic(body: string) {
+    // @ts-ignore
+    return this.parseDashboard(body);
+  }
+}
+
+const mockGithubApi = {} as GithubApi;
+
+describe("Dashboard Parsing", () => {
+  let dashboard: TestableDashboard;
+
+  beforeEach(() => {
+    dashboard = new TestableDashboard(mockGithubApi);
+  });
+
+  it("returns undefined for unsupported version", () => {
+    const body = dedent`<!-- VERSION: 0 -->
+      ## #123 Title
+      - \`branch/a\`: #124
+    `;
+
+    const entries = dashboard.parseDashboardPublic(body);
+    expect(entries).toBeUndefined();
+  });
+
+  it("parses a valid dashboard correctly", () => {
+    const body = dedent`<!-- VERSION: 1 -->
+      Header text...
+
+      ## #123 My PR Title
+      - \`branch/a\`: #124
+      - \`branch/b\`: owner/repo#125
+
+      ## #456 Another PR
+      - \`branch/c\`: #457
+    `;
+
+    const entries = dashboard.parseDashboardPublic(body);
+
+    if (entries === undefined) throw new Error("Entries should be defined");
+    expect(entries).toHaveLength(2);
+    expect(entries[0].originalPrNumber).toBe(123);
+    expect(entries[0].originalPrTitle).toBe("My PR Title");
+    expect(entries[0].backports).toHaveLength(2);
+    expect(entries[0].backports[0]).toEqual({
+      branch: "branch/a",
+      number: 124,
+    });
+    expect(entries[0].backports[1]).toEqual({
+      branch: "branch/b",
+      number: 125,
+    });
+
+    expect(entries[1].originalPrNumber).toBe(456);
+    expect(entries[1].originalPrTitle).toBe("Another PR");
+    expect(entries[1].backports).toHaveLength(1);
+    expect(entries[1].backports[0]).toEqual({
+      branch: "branch/c",
+      number: 457,
+    });
+  });
+
+  it("ignores malformed headers", () => {
+    const body = dedent`<!-- VERSION: 1 -->
+      ## # Not a number
+      - \`branch/a\`: #124
+
+      ## #123
+      - \`branch/b\`: #125
+
+      ## Just text
+    `;
+
+    const entries = dashboard.parseDashboardPublic(body);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("ignores malformed items", () => {
+    const body = dedent`<!-- VERSION: 1 -->
+      ## #123 Title
+      - Not an item
+      - \`branch\`: not-a-number
+      - \`\`: #124
+      - \`branch\`: #
+    `;
+
+    const entries = dashboard.parseDashboardPublic(body);
+    if (entries === undefined) throw new Error("Entries should be defined");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].backports).toHaveLength(0);
+  });
+
+  it("handles extra whitespace", () => {
+    const body = dedent`<!-- VERSION: 1 -->
+      
+      ## #123   Title with spaces  
+      -   \`branch/a\`  :   #124  
+    `;
+
+    const entries = dashboard.parseDashboardPublic(body);
+    if (entries === undefined) throw new Error("Entries should be defined");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].originalPrNumber).toBe(123);
+    expect(entries[0].originalPrTitle).toBe("Title with spaces");
+    expect(entries[0].backports[0]).toEqual({
+      branch: "branch/a",
+      number: 124,
+    });
+  });
+
+  it("is robust against markdown injection attempts in parsing", () => {
+    const body = dedent`<!-- VERSION: 1 -->
+      ## #123 Title with ## inside
+      - \`branch with \` inside\`: #124
+    `;
+
+    const entries = dashboard.parseDashboardPublic(body);
+    if (entries === undefined) throw new Error("Entries should be defined");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].originalPrNumber).toBe(123);
+    expect(entries[0].originalPrTitle).toBe("Title with ## inside");
+    expect(entries[0].backports).toHaveLength(1);
+    expect(entries[0].backports[0]).toEqual({
+      branch: "branch with ` inside",
+      number: 124,
+    });
+  });
+
+  it("is robust against nan", () => {
+    const body = dedent`<!-- VERSION: 1 -->
+      ## #nan Title with nan
+      - \`branch/a\`: #123
+      ## #124 Title with entry that has nan
+      - \`branch/a\`: #nan
+    `;
+    const entries = dashboard.parseDashboardPublic(body);
+    if (entries === undefined) throw new Error("Entries should be defined");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].originalPrNumber).toBe(124);
+    expect(entries[0].originalPrTitle).toBe("Title with entry that has nan");
+    expect(entries[0].backports).toHaveLength(0);
+  });
+});

--- a/src/test/dashboard_rendering.test.ts
+++ b/src/test/dashboard_rendering.test.ts
@@ -1,0 +1,92 @@
+import { Dashboard } from "../dashboard";
+import { GithubApi } from "../github";
+
+// Expose private method for testing
+class TestableDashboard extends Dashboard {
+  public renderDashboardPublic(entries: any[]) {
+    // @ts-ignore
+    return this.renderDashboard(entries);
+  }
+}
+
+const mockGithubApi = {} as GithubApi;
+
+describe("Dashboard Rendering", () => {
+  let dashboard: TestableDashboard;
+
+  beforeEach(() => {
+    dashboard = new TestableDashboard(mockGithubApi);
+  });
+
+  it("sanitizes PR titles by replacing newlines with spaces", () => {
+    const entries = [
+      {
+        originalPrNumber: 123,
+        originalPrTitle: "Title\nwith\nnewlines",
+        backports: [],
+      },
+    ];
+
+    const rendered = dashboard.renderDashboardPublic(entries);
+    expect(rendered).toContain("## #123 Title with newlines");
+    expect(rendered).not.toContain("Title\nwith\nnewlines");
+  });
+
+  it("escapes backticks in branch names", () => {
+    const entries = [
+      {
+        originalPrNumber: 123,
+        originalPrTitle: "Title",
+        backports: [
+          {
+            branch: "branch`with`backticks",
+            number: 124,
+          },
+        ],
+      },
+    ];
+
+    const rendered = dashboard.renderDashboardPublic(entries);
+    // Expect backticks to be escaped: `branch\`with\`backticks`
+    // In the rendered markdown list item: - `branch\`with\`backticks`: #124
+    expect(rendered).toContain("- `branch\\`with\\`backticks`: #124");
+  });
+
+  it("renders standard entries correctly", () => {
+    const entries = [
+      {
+        originalPrNumber: 123,
+        originalPrTitle: "Standard Title",
+        backports: [
+          {
+            branch: "feature/branch",
+            number: 124,
+          },
+        ],
+      },
+    ];
+
+    const rendered = dashboard.renderDashboardPublic(entries);
+    expect(rendered).toContain("## #123 Standard Title");
+    expect(rendered).toContain("- `feature/branch`: #124");
+  });
+
+  it("does not escape already escaped backticks", () => {
+    const entries = [
+      {
+        originalPrNumber: 123,
+        originalPrTitle: "Title",
+        backports: [
+          {
+            branch: "branch\\`with\\`escaped",
+            number: 124,
+          },
+        ],
+      },
+    ];
+
+    const rendered = dashboard.renderDashboardPublic(entries);
+    expect(rendered).toContain("- `branch\\`with\\`escaped`: #124");
+    expect(rendered).not.toContain("- `branch\\\\`with\\\\`escaped`: #124");
+  });
+});

--- a/src/test/dashboard_rendering.test.ts
+++ b/src/test/dashboard_rendering.test.ts
@@ -89,4 +89,10 @@ describe("Dashboard Rendering", () => {
     expect(rendered).toContain("- `branch\\`with\\`escaped`: #124");
     expect(rendered).not.toContain("- `branch\\\\`with\\\\`escaped`: #124");
   });
+
+  it("renders a note when there are no entries", () => {
+    const entries: any[] = [];
+    const rendered = dashboard.renderDashboardPublic(entries);
+    expect(rendered).toContain("No active backports.");
+  });
 });


### PR DESCRIPTION
This PR introduces a new experimental feature: the **Backport Dashboard**.

### Description
When enabled, the action maintains a single GitHub Issue that tracks the status of all backport pull requests created by the action. This provides maintainers with a centralized view of outstanding backports that need attention.

Check the Backport Dashboard in https://github.com/korthout/backport-action-test/issues/404 to see it in action.

### Features
* Creates and updates a "Backport Dashboard" issue listing original PRs and their associated backport PRs.
* Adds new backports to the list automatically as they are created.
* Automatically removes entries from the dashboard once all backports for a PR are merged or closed, keeping the list focused on active work.

### Security & Robustness
*   **Robust Parsing:** Implements a strict, line-by-line parser that produces data that is only used to construct the dashboard's body, protecting the action from injection attacks.
*   **Sanitization:** PR titles are sanitized (newlines removed) and branch names are escaped (backticks handled) to prevent rendering issues.
*   **Concurrency Safety:** We recommend using GitHub Action's `concurrency` groups to prevent race conditions during dashboard updates.

### Configuration
To enable the dashboard, add `dashboard_enabled: true` to the `experimental` input.

To create and update the dashboard, the action requires `issues:write` permissions in addition to the others. Additionally, it is **recommended** to configure `concurrency` to prevent serial updates to the dashboard from causing issues. 

```yaml
permissions:
  contents: write # so it can comment
  pull-requests: write # so it can create pull requests
  issues: write # so it can create/update the dashboard issue
jobs:
  backport:
    runs-on: ubuntu-latest
    # Serialize runs to prevent race conditions on the dashboard
    concurrency:
      group: backport-dashboard
      cancel-in-progress: false
    steps:
      - uses: actions/checkout@v4
      - name: Create backport pull requests
        uses: korthout/backport-action@v4
        with:
          experimental: >
            {
              "dashboard_enabled": true
            }
```

### Future extension options

I see potential to extend this in ways to make it more flexible. Currently, it's just a flag to enable/disable it, but we could add additional inputs to control the feature. For example, `dashboard_issue_number` would allow directly specifying the issue by number. Another example, would be to allow running the action only to clean up completed backport without actually creating new backports in a workflow that runs periodically.