### PR TITLE
refactor: rm force push mentioning

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -807,7 +807,6 @@ export class Backport {
         cd .worktree/${branchname}
         git reset --hard HEAD^
         git cherry-pick -x ${commitShasToCherryPick.join(" ")}
-        git push --force-with-lease
         \`\`\``;
       } else {
         return "";


### PR DESCRIPTION
## Challenge

The backport action opens a PR even for conflicts, and prints a helpful message.

```
git fetch origin backport-50223-to-stable/8.9
git worktree add --checkout .worktree/backport-50223-to-stable/8.9 backport-50223-to-stable/8.9
cd .worktree/backport-50223-to-stable/8.9
git reset --hard HEAD^
git cherry-pick -x f0af5a03ab58ac7b54c76bdb1d24a484b3f59526 e34d4905dce48cdef97cfad6690d07c30c6d8270 47091b34b41d2d075fa6ed8e3bb85cb845119f39 5fe63ba31af16add3df24d963cd5272c06804dbf c36dfef6ae73b4561aaf258878c9a084153a3bb7 66ba69b5933b0a58fd7d7bee57bbaf4ac5c75a28 fee1aecaf47dfe6fd5943b5d3639e1ac55d60d76
git push --force-with-lease
```
This message is printed this means the cherry-pick didn't succeed, and we have to do manual work.

 If we ran this locally, it would cause the cherry-pick to fail, but also to push without a commit (when failure happens on the first commit). This causes the previous opened Backport PR to be closed (which is confusing).


## Fix

 * Removed the force push command from the cherry-pick message

Example PRs where I encountered this:

 * https://github.com/camunda/camunda/pull/50770
 * https://github.com/camunda/camunda/pull/50769

> [!NOTE]
>
> Feel free to reject this. Was just an idea or suggestion.