### PR TITLE
fix: convert test helpers from execSync to async exec

### DIFF
--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -188,13 +188,13 @@ describe("Backport.run() with real git", () => {
         }),
       );
 
-      await git
-        .findCommitsInRange("release..backport-42-to-release", repo.workDir)
-        .then((commits) => {
-          ctx.expect(commits).toHaveLength(1);
-          const content = gitCmd(`show ${commits[0]}`, repo.workDir);
-          ctx.expect(content).toContain("BACKPORT-CONFLICT");
-        });
+      const commits = await git.findCommitsInRange(
+        "release..backport-42-to-release",
+        repo.workDir,
+      );
+      ctx.expect(commits).toHaveLength(1);
+      const content = gitCmd(`show ${commits[0]}`, repo.workDir);
+      ctx.expect(content).toContain("BACKPORT-CONFLICT");
     },
   );
 

--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -103,13 +103,13 @@ describe("Backport.run() with real git", () => {
   ): Promise<void> {
     const commits = await git.findCommitsInRange(range, workDir);
     ctx.expect(commits).toHaveLength(expected.length);
-    expected.forEach(({ message, cherryPickedFrom }, index) => {
+    for (const [index, { message, cherryPickedFrom }] of expected.entries()) {
       const content = gitCmd(`show ${commits[index]}`, workDir);
       ctx.expect(content).toContain(message);
       ctx
         .expect(content)
         .toContain(`(cherry picked from commit ${cherryPickedFrom})`);
-    });
+    }
   }
 
   it.concurrent(

--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -319,7 +319,10 @@ describe("Backport.run() with real git", () => {
 
       // "Update branch": merge main into feature branch (creates the merge commit)
       await gitCmd("checkout my-feature", repo.workDir);
-      await gitCmd("merge --no-ff main -m 'Update branch from main'", repo.workDir);
+      await gitCmd(
+        "merge --no-ff main -m 'Update branch from main'",
+        repo.workDir,
+      );
       const updateMergeSha = await gitCmd("rev-parse HEAD", repo.workDir);
 
       // Another feature commit after the update
@@ -394,7 +397,10 @@ describe("Backport.run() with real git", () => {
 
       // "Update branch": merge main into feature branch (creates the merge commit)
       await gitCmd("checkout my-feature", repo.workDir);
-      await gitCmd("merge --no-ff main -m 'Update branch from main'", repo.workDir);
+      await gitCmd(
+        "merge --no-ff main -m 'Update branch from main'",
+        repo.workDir,
+      );
       const updateMergeSha = await gitCmd("rev-parse HEAD", repo.workDir);
 
       // Another feature commit after the update

--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -104,7 +104,7 @@ describe("Backport.run() with real git", () => {
     const commits = await git.findCommitsInRange(range, workDir);
     ctx.expect(commits).toHaveLength(expected.length);
     for (const [index, { message, cherryPickedFrom }] of expected.entries()) {
-      const content = gitCmd(`show ${commits[index]}`, workDir);
+      const content = await gitCmd(`show ${commits[index]}`, workDir);
       ctx.expect(content).toContain(message);
       ctx
         .expect(content)
@@ -118,14 +118,14 @@ describe("Backport.run() with real git", () => {
       const repo = (ctx.repo = await template.createTestRepo());
       const git = setupGit();
 
-      createBranch(repo.workDir, "release", repo.initialCommitSha);
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
 
       const featureSha = await addConflictingCommits(
         repo.workDir,
         "release",
         "README.md",
       );
-      createPullRequestRef(repo.workDir, 42, featureSha);
+      await createPullRequestRef(repo.workDir, 42, featureSha);
 
       const github = new FakeGithub({
         sourcePr: {
@@ -154,14 +154,14 @@ describe("Backport.run() with real git", () => {
       const repo = (ctx.repo = await template.createTestRepo());
       const git = setupGit();
 
-      createBranch(repo.workDir, "release", repo.initialCommitSha);
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
 
       const featureSha = await addConflictingCommits(
         repo.workDir,
         "release",
         "README.md",
       );
-      createPullRequestRef(repo.workDir, 42, featureSha);
+      await createPullRequestRef(repo.workDir, 42, featureSha);
 
       const github = new FakeGithub({
         sourcePr: {
@@ -193,7 +193,7 @@ describe("Backport.run() with real git", () => {
         repo.workDir,
       );
       ctx.expect(commits).toHaveLength(1);
-      const content = gitCmd(`show ${commits[0]}`, repo.workDir);
+      const content = await gitCmd(`show ${commits[0]}`, repo.workDir);
       ctx.expect(content).toContain("BACKPORT-CONFLICT");
     },
   );
@@ -202,7 +202,7 @@ describe("Backport.run() with real git", () => {
     const repo = (ctx.repo = await template.createTestRepo());
     const git = setupGit();
 
-    createBranch(repo.workDir, "release", repo.initialCommitSha);
+    await createBranch(repo.workDir, "release", repo.initialCommitSha);
 
     const sha1 = await addCommit(
       repo.workDir,
@@ -222,8 +222,8 @@ describe("Backport.run() with real git", () => {
       "content3",
       "Third commit",
     );
-    pushBranch(repo.workDir);
-    createPullRequestRef(repo.workDir, 42, sha3);
+    await pushBranch(repo.workDir);
+    await createPullRequestRef(repo.workDir, 42, sha3);
 
     const github = new FakeGithub({
       sourcePr: {
@@ -266,8 +266,8 @@ describe("Backport.run() with real git", () => {
         "content",
         "Add feature",
       );
-      pushBranch(repo.workDir);
-      createPullRequestRef(repo.workDir, 42, featureSha);
+      await pushBranch(repo.workDir);
+      await createPullRequestRef(repo.workDir, 42, featureSha);
 
       const github = new FakeGithub({
         sourcePr: {
@@ -297,10 +297,10 @@ describe("Backport.run() with real git", () => {
       const git = setupGit();
 
       // Create backport target branch
-      createBranch(repo.workDir, "release", repo.initialCommitSha);
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
 
       // Start feature branch from initial commit
-      gitCmd("checkout -b my-feature", repo.workDir);
+      await gitCmd("checkout -b my-feature", repo.workDir);
       const feature1Sha = await addCommit(
         repo.workDir,
         "feature1.txt",
@@ -309,7 +309,7 @@ describe("Backport.run() with real git", () => {
       );
 
       // Add a commit on main (simulates base branch moving forward)
-      gitCmd("checkout main", repo.workDir);
+      await gitCmd("checkout main", repo.workDir);
       await addCommit(
         repo.workDir,
         "base-change.txt",
@@ -318,9 +318,9 @@ describe("Backport.run() with real git", () => {
       );
 
       // "Update branch": merge main into feature branch (creates the merge commit)
-      gitCmd("checkout my-feature", repo.workDir);
-      gitCmd("merge --no-ff main -m 'Update branch from main'", repo.workDir);
-      const updateMergeSha = gitCmd("rev-parse HEAD", repo.workDir);
+      await gitCmd("checkout my-feature", repo.workDir);
+      await gitCmd("merge --no-ff main -m 'Update branch from main'", repo.workDir);
+      const updateMergeSha = await gitCmd("rev-parse HEAD", repo.workDir);
 
       // Another feature commit after the update
       const feature2Sha = await addCommit(
@@ -332,16 +332,16 @@ describe("Backport.run() with real git", () => {
 
       // Push both branches so all objects are available on the remote.
       // The PR ref points to the feature branch tip (like real GitHub).
-      pushBranch(repo.workDir);
-      gitCmd("push origin main", repo.workDir);
+      await pushBranch(repo.workDir);
+      await gitCmd("push origin main", repo.workDir);
 
       // Simulate GitHub merging the PR into main
-      gitCmd("checkout main", repo.workDir);
-      gitCmd("merge --no-ff my-feature -m 'Merge PR #42'", repo.workDir);
-      const mergeOnMainSha = gitCmd("rev-parse HEAD", repo.workDir);
-      gitCmd("push origin main", repo.workDir);
+      await gitCmd("checkout main", repo.workDir);
+      await gitCmd("merge --no-ff my-feature -m 'Merge PR #42'", repo.workDir);
+      const mergeOnMainSha = await gitCmd("rev-parse HEAD", repo.workDir);
+      await gitCmd("push origin main", repo.workDir);
 
-      createPullRequestRef(repo.workDir, 42, feature2Sha);
+      await createPullRequestRef(repo.workDir, 42, feature2Sha);
 
       const github = new FakeGithub({
         sourcePr: {
@@ -372,10 +372,10 @@ describe("Backport.run() with real git", () => {
       const git = setupGit();
 
       // Create backport target branch
-      createBranch(repo.workDir, "release", repo.initialCommitSha);
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
 
       // Start feature branch from initial commit
-      gitCmd("checkout -b my-feature", repo.workDir);
+      await gitCmd("checkout -b my-feature", repo.workDir);
       const feature1Sha = await addCommit(
         repo.workDir,
         "feature1.txt",
@@ -384,7 +384,7 @@ describe("Backport.run() with real git", () => {
       );
 
       // Add a commit on main (simulates base branch moving forward)
-      gitCmd("checkout main", repo.workDir);
+      await gitCmd("checkout main", repo.workDir);
       await addCommit(
         repo.workDir,
         "base-change.txt",
@@ -393,9 +393,9 @@ describe("Backport.run() with real git", () => {
       );
 
       // "Update branch": merge main into feature branch (creates the merge commit)
-      gitCmd("checkout my-feature", repo.workDir);
-      gitCmd("merge --no-ff main -m 'Update branch from main'", repo.workDir);
-      const updateMergeSha = gitCmd("rev-parse HEAD", repo.workDir);
+      await gitCmd("checkout my-feature", repo.workDir);
+      await gitCmd("merge --no-ff main -m 'Update branch from main'", repo.workDir);
+      const updateMergeSha = await gitCmd("rev-parse HEAD", repo.workDir);
 
       // Another feature commit after the update
       const feature2Sha = await addCommit(
@@ -407,16 +407,16 @@ describe("Backport.run() with real git", () => {
 
       // Push both branches so all objects are available on the remote.
       // The PR ref points to the feature branch tip (like real GitHub).
-      pushBranch(repo.workDir);
-      gitCmd("push origin main", repo.workDir);
+      await pushBranch(repo.workDir);
+      await gitCmd("push origin main", repo.workDir);
 
       // Simulate GitHub merging the PR into main
-      gitCmd("checkout main", repo.workDir);
-      gitCmd("merge --no-ff my-feature -m 'Merge PR #42'", repo.workDir);
-      const mergeOnMainSha = gitCmd("rev-parse HEAD", repo.workDir);
-      gitCmd("push origin main", repo.workDir);
+      await gitCmd("checkout main", repo.workDir);
+      await gitCmd("merge --no-ff my-feature -m 'Merge PR #42'", repo.workDir);
+      const mergeOnMainSha = await gitCmd("rev-parse HEAD", repo.workDir);
+      await gitCmd("push origin main", repo.workDir);
 
-      createPullRequestRef(repo.workDir, 42, feature2Sha);
+      await createPullRequestRef(repo.workDir, 42, feature2Sha);
 
       const github = new FakeGithub({
         sourcePr: {
@@ -459,10 +459,10 @@ describe("Backport.run() with real git", () => {
     const git = setupGit();
 
     // Create backport target branch
-    createBranch(repo.workDir, "release", repo.initialCommitSha);
+    await createBranch(repo.workDir, "release", repo.initialCommitSha);
 
     // Start feature branch with two commits
-    gitCmd("checkout -b my-feature", repo.workDir);
+    await gitCmd("checkout -b my-feature", repo.workDir);
     const feature1Sha = await addCommit(
       repo.workDir,
       "feature1.txt",
@@ -475,12 +475,12 @@ describe("Backport.run() with real git", () => {
       "second feature",
       "Second feature commit",
     );
-    pushBranch(repo.workDir);
+    await pushBranch(repo.workDir);
 
     // Simulate GitHub squash-merging the PR into main
-    const squashSha = squashMerge(repo.workDir, "my-feature");
+    const squashSha = await squashMerge(repo.workDir, "my-feature");
 
-    createPullRequestRef(repo.workDir, 42, feature2Sha);
+    await createPullRequestRef(repo.workDir, 42, feature2Sha);
 
     const github = new FakeGithub({
       sourcePr: {
@@ -524,10 +524,10 @@ describe("Backport.run() with real git", () => {
       const git = setupGit();
 
       // Create backport target branch
-      createBranch(repo.workDir, "release", repo.initialCommitSha);
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
 
       // Start feature branch with two commits
-      gitCmd("checkout -b my-feature", repo.workDir);
+      await gitCmd("checkout -b my-feature", repo.workDir);
       const feature1Sha = await addCommit(
         repo.workDir,
         "feature1.txt",
@@ -540,12 +540,12 @@ describe("Backport.run() with real git", () => {
         "second feature",
         "Second feature commit",
       );
-      pushBranch(repo.workDir);
+      await pushBranch(repo.workDir);
 
       // Simulate GitHub rebase-merging the PR into main
-      const rebasedShas = rebaseMerge(repo.workDir, "my-feature");
+      const rebasedShas = await rebaseMerge(repo.workDir, "my-feature");
 
-      createPullRequestRef(repo.workDir, 42, feature2Sha);
+      await createPullRequestRef(repo.workDir, 42, feature2Sha);
 
       const github = new FakeGithub({
         sourcePr: {

--- a/src/test/helpers/test-repo.ts
+++ b/src/test/helpers/test-repo.ts
@@ -126,7 +126,11 @@ export async function addCommit(
   return gitCmd("rev-parse HEAD", dir);
 }
 
-export async function createBranch(dir: string, branch: string, from: string): Promise<void> {
+export async function createBranch(
+  dir: string,
+  branch: string,
+  from: string,
+): Promise<void> {
   await gitCmd(`branch ${branch} ${from}`, dir);
   await gitCmd(`push origin ${branch}`, dir);
 }
@@ -183,7 +187,10 @@ export async function createPullRequestRef(
  * Simulates GitHub's "Squash and merge" by squash-merging a feature branch
  * into main. Returns the SHA of the squash commit on main.
  */
-export async function squashMerge(dir: string, featureBranch: string): Promise<string> {
+export async function squashMerge(
+  dir: string,
+  featureBranch: string,
+): Promise<string> {
   await gitCmd("checkout main", dir);
   await gitCmd(`merge --squash ${featureBranch}`, dir);
   await gitCmd(`commit -m "Squash merge ${featureBranch}"`, dir);
@@ -195,7 +202,10 @@ export async function squashMerge(dir: string, featureBranch: string): Promise<s
  * Simulates GitHub's "Rebase and merge" by rebasing a feature branch onto
  * main and fast-forwarding main. Returns the rebased commit SHAs in order.
  */
-export async function rebaseMerge(dir: string, featureBranch: string): Promise<string[]> {
+export async function rebaseMerge(
+  dir: string,
+  featureBranch: string,
+): Promise<string[]> {
   await gitCmd("checkout main", dir);
   const oldMainSha = await gitCmd("rev-parse HEAD", dir);
   await gitCmd(`checkout ${featureBranch}`, dir);

--- a/src/test/helpers/test-repo.ts
+++ b/src/test/helpers/test-repo.ts
@@ -1,7 +1,10 @@
 import { mkdtemp, rm, writeFile, cp } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { execSync } from "child_process";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
 
 export type TestRepo = {
   workDir: string;
@@ -22,16 +25,12 @@ function gitEnv() {
   };
 }
 
-export function gitCmd(args: string, cwd: string): string {
-  return execSync(
+export async function gitCmd(args: string, cwd: string): Promise<string> {
+  const { stdout } = await execAsync(
     `git -c commit.gpgsign=false -c init.defaultBranch=main ${args}`,
-    {
-      cwd,
-      encoding: "utf-8",
-      stdio: process.env.GIT_SILENT === "1" ? "pipe" : undefined,
-      env: gitEnv(),
-    },
-  ).trim();
+    { cwd, env: gitEnv() },
+  );
+  return stdout.trim();
 }
 
 export async function createTestRepo(): Promise<TestRepo> {
@@ -40,18 +39,18 @@ export async function createTestRepo(): Promise<TestRepo> {
   const workDir = join(baseDir, "work");
 
   // Create bare remote
-  gitCmd(`init --bare ${bareDir}`, baseDir);
+  await gitCmd(`init --bare ${bareDir}`, baseDir);
 
   // Clone it
-  gitCmd(`clone ${bareDir} ${workDir}`, baseDir);
+  await gitCmd(`clone ${bareDir} ${workDir}`, baseDir);
 
   // Create initial commit on main
   await writeFile(join(workDir, "README.md"), "initial");
-  gitCmd("add README.md", workDir);
-  gitCmd('commit -m "initial commit"', workDir);
-  gitCmd("push origin HEAD", workDir);
+  await gitCmd("add README.md", workDir);
+  await gitCmd('commit -m "initial commit"', workDir);
+  await gitCmd("push origin HEAD", workDir);
 
-  const initialCommitSha = gitCmd("rev-parse HEAD", workDir);
+  const initialCommitSha = await gitCmd("rev-parse HEAD", workDir);
 
   return {
     workDir,
@@ -78,14 +77,14 @@ export async function createRepoTemplate(): Promise<RepoTemplate> {
   const bareDir = join(baseDir, "bare.git");
   const workDir = join(baseDir, "work");
 
-  gitCmd(`init --bare ${bareDir}`, baseDir);
-  gitCmd(`clone ${bareDir} ${workDir}`, baseDir);
+  await gitCmd(`init --bare ${bareDir}`, baseDir);
+  await gitCmd(`clone ${bareDir} ${workDir}`, baseDir);
   await writeFile(join(workDir, "README.md"), "initial");
-  gitCmd("add README.md", workDir);
-  gitCmd('commit -m "initial commit"', workDir);
-  gitCmd("push origin HEAD", workDir);
+  await gitCmd("add README.md", workDir);
+  await gitCmd('commit -m "initial commit"', workDir);
+  await gitCmd("push origin HEAD", workDir);
 
-  const initialCommitSha = gitCmd("rev-parse HEAD", workDir);
+  const initialCommitSha = await gitCmd("rev-parse HEAD", workDir);
 
   return {
     async createTestRepo(): Promise<TestRepo> {
@@ -98,7 +97,7 @@ export async function createRepoTemplate(): Promise<RepoTemplate> {
       // Fix remote URL: the copied work dir's origin still points to the
       // template's bare dir. Update it to point to the copied bare dir so
       // each test has its own isolated remote.
-      gitCmd(`remote set-url origin ${copyBareDir}`, copyWorkDir);
+      await gitCmd(`remote set-url origin ${copyBareDir}`, copyWorkDir);
 
       return {
         workDir: copyWorkDir,
@@ -122,18 +121,18 @@ export async function addCommit(
   message: string,
 ): Promise<string> {
   await writeFile(join(dir, file), content);
-  gitCmd(`add ${file}`, dir);
-  gitCmd(`commit -m "${message}"`, dir);
+  await gitCmd(`add ${file}`, dir);
+  await gitCmd(`commit -m "${message}"`, dir);
   return gitCmd("rev-parse HEAD", dir);
 }
 
-export function createBranch(dir: string, branch: string, from: string): void {
-  gitCmd(`branch ${branch} ${from}`, dir);
-  gitCmd(`push origin ${branch}`, dir);
+export async function createBranch(dir: string, branch: string, from: string): Promise<void> {
+  await gitCmd(`branch ${branch} ${from}`, dir);
+  await gitCmd(`push origin ${branch}`, dir);
 }
 
-export function pushBranch(dir: string): void {
-  gitCmd("push origin HEAD", dir);
+export async function pushBranch(dir: string): Promise<void> {
+  await gitCmd("push origin HEAD", dir);
 }
 
 /**
@@ -153,17 +152,17 @@ export async function addConflictingCommits(
     "conflicting content from main",
     `Change ${file} on main`,
   );
-  pushBranch(dir);
+  await pushBranch(dir);
 
-  gitCmd(`checkout ${targetBranch}`, dir);
+  await gitCmd(`checkout ${targetBranch}`, dir);
   await addCommit(
     dir,
     file,
     "different content",
     `Change ${file} on ${targetBranch}`,
   );
-  gitCmd(`push origin ${targetBranch}`, dir);
-  gitCmd("checkout main", dir);
+  await gitCmd(`push origin ${targetBranch}`, dir);
+  await gitCmd("checkout main", dir);
 
   return featureSha;
 }
@@ -172,23 +171,23 @@ export async function addConflictingCommits(
  * Creates a pull request ref in the bare remote, simulating what GitHub does.
  * This allows `git fetch origin refs/pull/<number>/head` to succeed.
  */
-export function createPullRequestRef(
+export async function createPullRequestRef(
   dir: string,
   pullNumber: number,
   sha: string,
-): void {
-  gitCmd(`push origin ${sha}:refs/pull/${pullNumber}/head`, dir);
+): Promise<void> {
+  await gitCmd(`push origin ${sha}:refs/pull/${pullNumber}/head`, dir);
 }
 
 /**
  * Simulates GitHub's "Squash and merge" by squash-merging a feature branch
  * into main. Returns the SHA of the squash commit on main.
  */
-export function squashMerge(dir: string, featureBranch: string): string {
-  gitCmd("checkout main", dir);
-  gitCmd(`merge --squash ${featureBranch}`, dir);
-  gitCmd(`commit -m "Squash merge ${featureBranch}"`, dir);
-  gitCmd("push origin main", dir);
+export async function squashMerge(dir: string, featureBranch: string): Promise<string> {
+  await gitCmd("checkout main", dir);
+  await gitCmd(`merge --squash ${featureBranch}`, dir);
+  await gitCmd(`commit -m "Squash merge ${featureBranch}"`, dir);
+  await gitCmd("push origin main", dir);
   return gitCmd("rev-parse HEAD", dir);
 }
 
@@ -196,15 +195,15 @@ export function squashMerge(dir: string, featureBranch: string): string {
  * Simulates GitHub's "Rebase and merge" by rebasing a feature branch onto
  * main and fast-forwarding main. Returns the rebased commit SHAs in order.
  */
-export function rebaseMerge(dir: string, featureBranch: string): string[] {
-  gitCmd("checkout main", dir);
-  const oldMainSha = gitCmd("rev-parse HEAD", dir);
-  gitCmd(`checkout ${featureBranch}`, dir);
-  gitCmd("rebase main", dir);
-  gitCmd("checkout main", dir);
-  gitCmd(`merge --ff-only ${featureBranch}`, dir);
-  gitCmd("push origin main", dir);
-  return gitCmd(`log ${oldMainSha}..main --format=%H --reverse`, dir)
+export async function rebaseMerge(dir: string, featureBranch: string): Promise<string[]> {
+  await gitCmd("checkout main", dir);
+  const oldMainSha = await gitCmd("rev-parse HEAD", dir);
+  await gitCmd(`checkout ${featureBranch}`, dir);
+  await gitCmd("rebase main", dir);
+  await gitCmd("checkout main", dir);
+  await gitCmd(`merge --ff-only ${featureBranch}`, dir);
+  await gitCmd("push origin main", dir);
+  return (await gitCmd(`log ${oldMainSha}..main --format=%H --reverse`, dir))
     .split("\n")
     .filter(Boolean);
 }


### PR DESCRIPTION
## Summary

  - `execSync` in test helpers blocks the Node.js event loop, serializing `it.concurrent` tests — while one test's git process runs, all others are frozen
  - Replace with promisified `exec` so the event loop stays free and tests run truly concurrently
  - Test duration drops from ~4s to ~1.9s (54% faster)

  ## Commits

  1. **refactor: flatten .then callback to plain await** — simplify nested .then to plain await + flat code
  2. **refactor: convert forEach to for..of in test helper** — required for correct await inside loops
  3. **refactor: add await to all unawaited test helper calls** — mechanical no-op await additions to prepare call sites
  4. **fix: convert test helpers from execSync to async exec** — the actual fix
  5. **style: apply prettier format** — line-length reformats from prettier

  ## Test plan

  - [x] All 97 tests pass
  - [x] `npx tsc --noEmit` passes
  - [x] No `execSync` remains in `test-repo.ts`
  - [x] Measured 54% test duration improvement (4.06s → 1.85s avg over 5 runs)