### PR TITLE
ci: replace gha-find-replace with sed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set release version in package.json
-        uses: jacobtomlinson/gha-find-replace@f1069b438f125e5395d84d1c6fd3b559a7880cb5 # 3.0.5
-        with:
-          find: '"version": "[0-9\.]+(-SNAPSHOT)?"'
-          replace: '"version": "${{ inputs.releaseVersion }}"'
-          include: package.json
-          regex: true
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+        run: |
+          sed -i "s/\"version\": \"[0-9.]*\(-SNAPSHOT\)\{0,1\}\"/\"version\": \"$RELEASE_VERSION\"/" package.json
 
       - name: Commit new release version
         id: commit-new-release
@@ -45,12 +43,11 @@ jobs:
         run: git show ${{ steps.commit-new-release.outputs.commit_sha }} | cat
 
       - name: Set development version in package.json
-        uses: jacobtomlinson/gha-find-replace@f1069b438f125e5395d84d1c6fd3b559a7880cb5 # 3.0.5
-        with:
-          find: '"version": "${{ inputs.releaseVersion }}"'
-          replace: '"version": "${{ inputs.nextDevelopmentVersion }}"'
-          include: "package.json"
-          regex: false
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+          NEXT_VERSION: ${{ inputs.nextDevelopmentVersion }}
+        run: |
+          sed -i "s/\"version\": \"$RELEASE_VERSION\"/\"version\": \"$NEXT_VERSION\"/" package.json
 
       - name: Extract semver release version components
         uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba # v4.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,18 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version inputs
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+          NEXT_VERSION: ${{ inputs.nextDevelopmentVersion }}
+        run: |
+          for v in "$RELEASE_VERSION" "$NEXT_VERSION"; do
+            if ! echo "$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+              printf '::error::Invalid semver: %s\n' "$v"
+              exit 1
+            fi
+          done
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set release version in package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}
         run: |
           sed -i "s/\"version\": \"[0-9.]*\(-SNAPSHOT\)\{0,1\}\"/\"version\": \"$RELEASE_VERSION\"/" package.json
+          grep -Fq "\"version\": \"$RELEASE_VERSION\"" package.json
 
       - name: Commit new release version
         id: commit-new-release
@@ -48,6 +49,7 @@ jobs:
           NEXT_VERSION: ${{ inputs.nextDevelopmentVersion }}
         run: |
           sed -i "s/\"version\": \"$RELEASE_VERSION\"/\"version\": \"$NEXT_VERSION\"/" package.json
+          grep -Fq "\"version\": \"$NEXT_VERSION\"" package.json
 
       - name: Extract semver release version components
         uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba # v4.3.0


### PR DESCRIPTION
## Summary

The `jacobtomlinson/gha-find-replace` action used in the release workflow is unmaintained. This PR removes the dependency entirely by replacing it with inline `sed` commands — the operation is a simple version string replacement in `package.json`, so a dedicated action is unnecessary.

- Pass inputs through environment variables to prevent shell injection
- Validate inputs are semver before use, structurally guaranteeing only safe characters reach substitution
- Add `grep -Fq` verification after each replacement to fail fast on silent no-ops

## Test plan
- [x] Trigger a dry-run release and verify both version replacements work correctly
- [ ] Trigger a dry-run with an invalid version string and verify the workflow fails at validation