### PR TITLE
Add merge queue support and Renovate automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,11 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",
     ":semanticCommitsDisabled"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,8 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group: {}
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 'release-*'
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,27 @@
+# CI Design
+
+## Workflows
+
+- **CI** (`ci.yml`) validates PRs and merge queue entries (format-check, build, package, test).
+- **Publish** (`publish.yml`) commits built `dist/` artifacts after merges to `main` and `release-*` branches.
+- **Release** (`release.yml`) stamps versions and creates tags (manual trigger). Does not build `dist/` itself -- Publish handles that when Release pushes to `main` or `release-*`.
+- **Backport** (`backport.yml`) cherry-picks merged PRs to release branches via the backport-action itself.
+
+## Why dist/ is committed post-merge, not in PRs
+
+Backporting cherry-picks PR commits to release branches.
+Since `dist/` differs across branches, including `dist/` in PRs causes merge conflicts during backporting.
+The Publish workflow builds and commits `dist/` separately after each merge, avoiding this.
+
+It is fine to temporarily include `dist/` in a PR branch for E2E testing (via [backport-action-test](https://github.com/korthout/backport-action-test)) or manual testing, but `dist/` changes should be removed before merging to support backporting the PR.
+
+## Publish concurrency
+
+When multiple PRs merge via the merge queue in quick succession, overlapping Publish runs can race.
+The `cancel-in-progress` concurrency group ensures only the latest run completes.
+If a stale run's push fails (non-fast-forward because `main` moved), it is harmless -- the latest run handles it.
+
+## Merge queue and Publish interaction
+
+Each Publish commit to `main` can invalidate the next queued PR's merge group, causing a re-test.
+With merge queue batching (`max_entries_to_merge > 1`), multiple PRs merge in one ref update, triggering only one Publish run and avoiding this invalidation cascade.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ npm run all
 
 This action can also be tested end-to-end using [korthout/backport-action-test](https://github.com/korthout/backport-action-test).
 
+### CI Design
+
+For details on why `dist/` is not committed in PRs and how the CI workflows interact, see [CI.md](CI.md).
+
 ### Releases
 
 The distribution is hosted in this repository under `dist`.


### PR DESCRIPTION
## Summary

Add merge queue support so that multiple PRs (e.g., Renovate dependency updates) can be queued for merging without having to manually wait between each one for CI and the Publish workflow to complete.

- Add `merge_group` trigger to CI workflow so it runs on merge queue entries
- Add `cancel-in-progress` concurrency group to Publish workflow to handle racing runs when multiple PRs merge in quick succession
- Enable Renovate automerge for patch, pin, and digest updates
- Add CI design documentation (`CI.md`) explaining why `dist/` is committed post-merge and how the merge queue interacts with Publish

## Merge queue setup

After merging, configure the merge queue in the repo's ruleset settings:

| Setting | Value |
|---------|-------|
| Grouping strategy | ALLGREEN |
| Merge method | MERGE |
| Max entries to build | 5 |
| Max entries to merge | 5 |
| Min entries to merge | 1 |
| Min entries to merge wait minutes | 3 |
| Required status check | `build` |

## Test plan

- [ ] Verify CI triggers on `merge_group` events after enabling the merge queue
- [ ] Verify Publish runs with concurrency group after merging multiple PRs
- [ ] Verify Renovate patch PRs auto-enter the merge queue