### PR TITLE
Remove merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  merge_group: {}
 
 jobs:
   build:

--- a/CI.md
+++ b/CI.md
@@ -2,7 +2,7 @@
 
 ## Workflows
 
-- **CI** (`ci.yml`) validates PRs and merge queue entries (format-check, build, package, test).
+- **CI** (`ci.yml`) validates PRs (format-check, build, package, test).
 - **Publish** (`publish.yml`) commits built `dist/` artifacts after merges to `main` and `release-*` branches.
 - **Release** (`release.yml`) stamps versions and creates tags (manual trigger). Does not build `dist/` itself -- Publish handles that when Release pushes to `main` or `release-*`.
 - **Backport** (`backport.yml`) cherry-picks merged PRs to release branches via the backport-action itself.
@@ -17,11 +17,6 @@ It is fine to temporarily include `dist/` in a PR branch for E2E testing (via [b
 
 ## Publish concurrency
 
-When multiple PRs merge via the merge queue in quick succession, overlapping Publish runs can race.
+When multiple PRs merge in quick succession, overlapping Publish runs can race.
 The `cancel-in-progress` concurrency group ensures only the latest run completes.
 If a stale run's push fails (non-fast-forward because `main` moved), it is harmless -- the latest run handles it.
-
-## Merge queue and Publish interaction
-
-Each Publish commit to `main` can invalidate the next queued PR's merge group, causing a re-test.
-With merge queue batching (`max_entries_to_merge > 1`), multiple PRs merge in one ref update, triggering only one Publish run and avoiding this invalidation cascade.


### PR DESCRIPTION
Merge queue is not available for personal repos on GitHub. Keep the Publish concurrency section as it applies to regular auto-merge too.