### PR TITLE
Configure Mergify merge queue

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,8 +8,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true,
-      "platformAutomerge": true
+      "addLabels": ["automerge"]
     }
   ]
 }

--- a/.github/workflows/pr-info.yml
+++ b/.github/workflows/pr-info.yml
@@ -1,0 +1,29 @@
+name: PR Info
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post merge instructions
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const author = context.payload.pull_request.user.login;
+            const isAutoMerge = labels.includes('automerge') && author === 'renovate[bot]';
+            const message = isAutoMerge
+              ? 'This PR will be merged automatically once the build check passes.'
+              : 'This PR can be added to the merge queue by commenting `@mergifyio queue`.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            });

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,7 @@ pull_request_rules:
     conditions:
       - author = renovate[bot]
       - check-success = build
+      - label = automerge
       - label != do-not-merge
     actions:
       queue:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,20 @@
+merge_queue:
+  reset_on_external_merge: never
+
 queue_rules:
-  - name: queue
+  - name: default
     merge_method: merge
+    queue_conditions:
+      - check-success = build
+    merge_conditions:
+      - check-success = build
+
+pull_request_rules:
+  - name: automatic merge for Renovate patch updates
+    conditions:
+      - author = renovate[bot]
+      - check-success = build
+      - label != do-not-merge
+    actions:
+      queue:
+        name: default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,18 @@ This action can also be tested end-to-end using [korthout/backport-action-test](
 
 For details on why `dist/` is not committed in PRs and how the CI workflows interact, see [CI.md](CI.md).
 
+### Merging
+
+This repository uses [Mergify](https://mergify.com) to manage a merge queue.
+PRs are merged through the queue to ensure they are tested against the latest `main` branch before merging.
+
+To add a PR to the merge queue, comment `@mergifyio queue` on the PR.
+Renovate patch updates are automatically queued when CI passes.
+
+PRs should not include changes to `dist/` — it is rebuilt automatically after merge by the Publish workflow.
+It's fine to temporarily commit `dist/` for testing purposes, but those changes should be removed before merging.
+See [CI.md](CI.md) for details.
+
 ### Releases
 
 The distribution is hosted in this repository under `dist`.


### PR DESCRIPTION
## Summary

Add merge queue support so that multiple PRs (e.g., Renovate dependency updates) can be queued for merging without having to manually wait between each one for CI and the Publish workflow to complete.

- Configure Mergify queue rules with `reset_on_external_merge: never` to prevent the Publish workflow's dist/ commits from resetting the queue
- Auto-queue Renovate patch/pin/digest PRs when CI passes
- Document the merge queue and dist/ guidance in CONTRIBUTING.md

## Design decisions

- **`reset_on_external_merge: never`**: The Publish workflow commits dist/ to main after each merge. Without this setting, each Publish commit resets the entire queue. This is safe because CI builds from source, not from dist/.
- **`merge_method: merge`**: Preserves individual commits for cherry-pick backporting to release branches.
- **Renovate auto-queue**: Gated on `author = renovate[bot]` (enforced by GitHub, cannot be spoofed) and `check-success = build`. A `do-not-merge` label provides an escape hatch.

## Related setup

- Branch rulesets configured for `main` and `release-*` (require PR and `build` check on main, restrict deletions and force pushes on both)
- Mergify GitHub App installed and merge queue product enabled
