### PR TITLE
refactor: restructure backport.ts for readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+GitHub Action that backports merged PRs to other branches.
+
+## Product values
+
+Preserve when making changes:
+- **Fast** — the action runs quickly for end users
+- **No inputs required** — sensible defaults; drop-in usable
+- **Flexible & configurable** — handles different trigger events and contexts; configurable to fit different use cases
+- **Clear** — the action communicates what it did (and what it tried)
+
+## Don't break user space
+
+Any behavioral change a user didn't explicitly configure is forbidden. This includes action `inputs`/`outputs`, the workflow events the action runs on, and assumptions about the environment (e.g. the checked-out git repository).
+
+## Maintainability
+
+This action has many users; maintainer burden compounds. When facing tradeoffs, prefer obvious code over clever abstractions, fewer dependencies over more, and changes that don't complicate the release flow. Existing style isn't sacred — when touching code, diverge from the surrounding pattern when it improves maintainability.
+
+## Code
+
+- Modern, idiomatic TypeScript
+- Two external boundaries: `GithubApi` (`src/github.ts`) and `GitApi` (`src/git.ts`) — see TESTING.md
+- `package-lock.json` is authoritative. Don't run `npm install` to "fix" things — investigate the root cause
+
+## Working in this repo
+
+- Run `npm run all` before declaring a change done (format + build + package + test)
+- Tests: `npm test` (or `npm run test-verbose` for individual names)
+- **Never commit `dist/` in a PR** — the Publish workflow rebuilds it post-merge; including it breaks backporting (see CI.md)
+- Merging goes through the Mergify queue (`@mergifyio queue`) — don't merge or push to `main` directly
+
+## Pointers
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — build, package, release flow
+- [TESTING.md](TESTING.md) — test architecture, where to add tests, E2E
+- [CI.md](CI.md) — CI workflows, the `dist/` rule, Publish concurrency

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,7 @@
 # Testing
 
+This repo uses [Vitest](https://vitest.dev), not Jest.
+
 ## Running tests
 
 ```

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -4,11 +4,14 @@ import dedent from "dedent";
 import {
   CreatePullRequestResponse,
   PullRequest,
-  MergeStrategy,
   RequestError,
 } from "./github.js";
 import { GithubApi } from "./github.js";
 import { GitApi, GitRefNotFoundError } from "./git.js";
+import {
+  MergeCommitsNotAllowedError,
+  resolveCommitsToCherryPick,
+} from "./resolve-commits.js";
 import * as utils from "./utils.js";
 
 type PRContent = {
@@ -140,111 +143,28 @@ export class Backport {
         return; // nothing left to do here
       }
 
-      console.log(
-        `Fetching all the commits from the pull request: ${mainpr.commits + 1}`,
-      );
-      await this.git.fetch(
-        `refs/pull/${pull_number}/head`,
-        this.config.pwd,
-        mainpr.commits + 1, // +1 in case this concerns a shallowly cloned repo
-      );
-
-      const commitShas = await this.github.getCommits(mainpr);
-
-      let commitShasToCherryPick;
-
-      if (this.config.commits.cherry_picking === "auto") {
-        const merge_commit_sha = await this.github.getMergeCommitSha(mainpr);
-
-        // switch case to check if it is a squash, rebase, or merge commit
-        switch (await this.github.mergeStrategy(mainpr, merge_commit_sha)) {
-          case MergeStrategy.SQUASHED:
-            // If merged via a squash merge_commit_sha represents the SHA of the squashed commit on
-            // the base branch. We must fetch it and its parent in case of a shallowly cloned repo
-            // To store the fetched commits indefinitely we save them to a remote ref using the sha
-            await this.git.fetch(
-              `+${merge_commit_sha}:refs/remotes/origin/${merge_commit_sha}`,
-              this.config.pwd,
-              2, // +1 in case this concerns a shallowly cloned repo
-            );
-            commitShasToCherryPick = [merge_commit_sha!];
-            break;
-          case MergeStrategy.REBASED:
-            // If rebased merge_commit_sha represents the commit that the base branch was updated to
-            // We must fetch it, its parents, and one extra parent in case of a shallowly cloned repo
-            // To store the fetched commits indefinitely we save them to a remote ref using the sha
-            await this.git.fetch(
-              `+${merge_commit_sha}:refs/remotes/origin/${merge_commit_sha}`,
-              this.config.pwd,
-              mainpr.commits + 1, // +1 in case this concerns a shallowly cloned repo
-            );
-            const range = `${merge_commit_sha}~${mainpr.commits}..${merge_commit_sha}`;
-            commitShasToCherryPick = await this.git.findCommitsInRange(
-              range,
-              this.config.pwd,
-            );
-            break;
-          case MergeStrategy.MERGECOMMIT:
-            commitShasToCherryPick = commitShas;
-            break;
-          case MergeStrategy.UNKNOWN:
-            console.log(
-              "Could not detect merge strategy. Using commits from the Pull Request.",
-            );
-            commitShasToCherryPick = commitShas;
-            break;
-          default:
-            console.log(
-              "Could not detect merge strategy. Using commits from the Pull Request.",
-            );
-            commitShasToCherryPick = commitShas;
-            break;
+      let commitShasToCherryPick: string[];
+      try {
+        commitShasToCherryPick = await resolveCommitsToCherryPick(
+          this.git,
+          this.github,
+          this.config,
+          mainpr,
+          pull_number,
+        );
+      } catch (error) {
+        if (error instanceof MergeCommitsNotAllowedError) {
+          console.error(error.message);
+          this.github.createComment({
+            owner: workflowOwner,
+            repo: workflowRepo,
+            issue_number: pull_number,
+            body: error.message,
+          });
+          return;
         }
-      } else {
-        console.log(
-          "Not detecting merge strategy. Using commits from the Pull Request.",
-        );
-        commitShasToCherryPick = commitShas;
+        throw error;
       }
-      console.log(`Found commits to backport: ${commitShasToCherryPick}`);
-
-      console.log("Checking the merged pull request for merge commits");
-      const mergeCommitShas = await this.git.findMergeCommits(
-        commitShasToCherryPick,
-        this.config.pwd,
-      );
-      console.log(
-        `Encountered ${mergeCommitShas.length ?? "no"} merge commits`,
-      );
-      if (
-        mergeCommitShas.length > 0 &&
-        this.config.commits.merge_commits == "fail"
-      ) {
-        const message = dedent`Backport failed because this pull request contains merge commits. \
-          You can either backport this pull request manually, or configure the action to skip merge commits.`;
-        console.error(message);
-        this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pull_number,
-          body: message,
-        });
-        return;
-      }
-
-      if (
-        mergeCommitShas.length > 0 &&
-        this.config.commits.merge_commits == "skip"
-      ) {
-        console.log("Skipping merge commits: " + mergeCommitShas);
-        const nonMergeCommitShas = commitShasToCherryPick.filter(
-          (sha) => !mergeCommitShas.includes(sha),
-        );
-        commitShasToCherryPick = nonMergeCommitShas;
-      }
-      console.log(
-        "Will cherry-pick the following commits: " + commitShasToCherryPick,
-      );
 
       let labelsToCopy: string[] = [];
       if (typeof this.config.copy_labels_pattern !== "undefined") {

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -345,11 +345,7 @@ export class Backport {
           status: "failed",
           targetBranch,
           branchname,
-          error: new CheckoutError(
-            message,
-            branchname,
-            commitShasToCherryPick,
-          ),
+          error: new CheckoutError(message, branchname, commitShasToCherryPick),
         };
       }
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -8,6 +8,7 @@ import {
 } from "./github.js";
 import { GithubApi } from "./github.js";
 import { GitApi, GitRefNotFoundError } from "./git.js";
+import { postCreatePR } from "./pr-post-create.js";
 import {
   MergeCommitsNotAllowedError,
   resolveCommitsToCherryPick,
@@ -356,219 +357,15 @@ export class Backport {
           }
           const new_pr = new_pr_response.data;
 
-          if (this.config.copy_milestone == true) {
-            const milestone = mainpr.milestone?.number;
-            if (milestone) {
-              console.info("Setting milestone to " + milestone);
-              try {
-                await this.github.setMilestone(new_pr.number, milestone);
-              } catch (error) {
-                if (!(error instanceof RequestError)) throw error;
-                console.error(JSON.stringify(error.response));
-              }
-            }
-          }
-
-          if (this.config.copy_assignees == true) {
-            const assignees =
-              mainpr.assignees?.map((label) => label.login) ?? [];
-            if (assignees.length > 0) {
-              console.info("Setting assignees " + assignees);
-              try {
-                await this.github.addAssignees(new_pr.number, assignees, {
-                  owner: targetOwner,
-                  repo: targetRepo,
-                });
-              } catch (error) {
-                if (!(error instanceof RequestError)) throw error;
-                console.error(JSON.stringify(error.response));
-              }
-            }
-          }
-
-          if (this.config.copy_all_reviewers == true) {
-            const requestedReviewers =
-              mainpr.requested_reviewers?.map((reviewer) => reviewer.login) ??
-              [];
-
-            let submittedReviewers: string[] = [];
-            try {
-              const { data: reviews } = await this.github.listReviews(
-                workflowOwner,
-                workflowRepo,
-                mainpr.number,
-              );
-
-              submittedReviewers = [
-                ...new Set(
-                  reviews
-                    .map((review) => review.user?.login)
-                    .filter((login): login is string => Boolean(login)),
-                ),
-              ];
-            } catch (error) {
-              if (!(error instanceof RequestError)) throw error;
-              console.error(JSON.stringify(error.response));
-            }
-
-            const reviewers = [
-              ...new Set([...requestedReviewers, ...submittedReviewers]),
-            ];
-
-            if (reviewers.length > 0) {
-              console.info("Setting reviewers " + reviewers);
-              const reviewRequest = {
-                owner: targetOwner,
-                repo: targetRepo,
-                pull_number: new_pr.number,
-                reviewers: reviewers,
-              };
-              try {
-                await this.github.requestReviewers(reviewRequest);
-              } catch (error) {
-                if (!(error instanceof RequestError)) throw error;
-                console.error(JSON.stringify(error.response));
-              }
-            }
-          }
-
-          if (this.config.copy_requested_reviewers == true) {
-            const reviewers =
-              mainpr.requested_reviewers?.map((reviewer) => reviewer.login) ??
-              [];
-            if (reviewers.length > 0) {
-              console.info("Setting reviewers " + reviewers);
-              const reviewRequest = {
-                owner: targetOwner,
-                repo: targetRepo,
-                pull_number: new_pr.number,
-                reviewers: reviewers,
-              };
-              try {
-                await this.github.requestReviewers(reviewRequest);
-              } catch (error) {
-                if (!(error instanceof RequestError)) throw error;
-                console.error(JSON.stringify(error.response));
-              }
-            }
-          }
-
-          // Combine the labels to be copied with the static labels and deduplicate them using a Set
-          const labels = [
-            ...new Set([...labelsToCopy, ...this.config.add_labels]),
-          ];
-          if (labels.length > 0) {
-            try {
-              await this.github.labelPR(new_pr.number, labels, {
-                owner: targetOwner,
-                repo: targetRepo,
-              });
-            } catch (error) {
-              if (!(error instanceof RequestError)) throw error;
-              console.error(JSON.stringify(error.response));
-              // The PR was still created so let's still comment on the original.
-            }
-          }
-
-          if (this.config.add_author_as_assignee == true) {
-            const author = mainpr.user.login;
-            console.info("Setting " + author + " as assignee");
-            try {
-              await this.github.addAssignees(new_pr.number, [author], {
-                owner: targetOwner,
-                repo: targetRepo,
-              });
-            } catch (error) {
-              if (!(error instanceof RequestError)) throw error;
-              console.error(JSON.stringify(error.response));
-            }
-          }
-
-          if (this.config.add_author_as_reviewer == true) {
-            const author = mainpr.user.login;
-            console.info("Requesting review from " + author);
-            try {
-              await this.github.requestReviewers({
-                owner: targetOwner,
-                repo: targetRepo,
-                pull_number: new_pr.number,
-                reviewers: [author],
-              });
-            } catch (error) {
-              if (!(error instanceof RequestError)) throw error;
-              console.error(JSON.stringify(error.response));
-            }
-          }
-
-          const addedReviewers = [...new Set(this.config.add_reviewers)];
-          if (addedReviewers.length > 0) {
-            console.info("Adding reviewers: " + addedReviewers);
-            try {
-              await this.github.requestReviewers({
-                owner: targetOwner,
-                repo: targetRepo,
-                pull_number: new_pr.number,
-                reviewers: addedReviewers,
-              });
-            } catch (error) {
-              if (!(error instanceof RequestError)) throw error;
-              console.error(JSON.stringify(error.response));
-            }
-          }
-
-          const addedTeamReviewers = [
-            ...new Set(this.config.add_team_reviewers),
-          ];
-          if (addedTeamReviewers.length > 0) {
-            console.info("Adding team reviewers: " + addedTeamReviewers);
-            try {
-              await this.github.requestReviewers({
-                owner: targetOwner,
-                repo: targetRepo,
-                pull_number: new_pr.number,
-                reviewers: [],
-                team_reviewers: addedTeamReviewers,
-              } as any);
-            } catch (error) {
-              if (!(error instanceof RequestError)) throw error;
-              console.error(JSON.stringify(error.response));
-            }
-          }
-
-          if (this.config.auto_merge_enabled === true) {
-            console.info(
-              "Attempting to enable auto-merge for PR #" + new_pr.number,
-            );
-            try {
-              await this.github.enableAutoMerge(
-                new_pr.number,
-                {
-                  owner: targetOwner,
-                  repo: targetRepo,
-                },
-                this.config.auto_merge_method,
-              );
-              console.info(
-                "Successfully enabled auto-merge for PR #" + new_pr.number,
-              );
-            } catch (error) {
-              if (!(error instanceof RequestError)) throw error;
-
-              // Handle auto-merge failures gracefully
-              const errorMessage = this.getAutoMergeErrorMessage(
-                error,
-                this.config.auto_merge_method,
-              );
-              console.warn(
-                `Failed to enable auto-merge for PR #${new_pr.number}: ${errorMessage}`,
-              );
-              console.warn(
-                "The backport PR was created successfully, but auto-merge could not be enabled.",
-              );
-
-              // The PR was still created so let's still comment on the original.
-            }
-          }
+          await postCreatePR(
+            this.github,
+            this.config,
+            new_pr.number,
+            mainpr,
+            labelsToCopy,
+            { owner: targetOwner, repo: targetRepo },
+            { owner: workflowOwner, repo: workflowRepo },
+          );
 
           // post success message to original pr
           {
@@ -820,54 +617,6 @@ export class Backport {
 
     const createdPullNumbersOutput = createdPullRequestNumbers.join(" ");
     core.setOutput(Output.created_pull_numbers, createdPullNumbersOutput);
-  }
-
-  private getAutoMergeErrorMessage(
-    error: RequestError,
-    mergeMethod: string,
-  ): string {
-    const errorStr = JSON.stringify(error.response?.data) || error.message;
-
-    // Check for common auto-merge error scenarios
-    if (errorStr.includes("auto-merge") && errorStr.includes("not allowed")) {
-      return `Repository does not have "Allow auto-merge" enabled. Please enable it in repository Settings > General > Pull Requests.`;
-    }
-
-    if (
-      errorStr.includes("merge commits are not allowed") ||
-      errorStr.includes("Merge method merge commits are not allowed")
-    ) {
-      return `Repository does not allow merge commits. Try using 'auto_merge_method: squash' or 'auto_merge_method: rebase' instead.`;
-    }
-
-    if (errorStr.includes("squash") && errorStr.includes("not allowed")) {
-      return `Repository does not allow squash merging. Try using 'auto_merge_method: merge' or 'auto_merge_method: rebase' instead.`;
-    }
-
-    if (errorStr.includes("rebase") && errorStr.includes("not allowed")) {
-      return `Repository does not allow rebase merging. Try using 'auto_merge_method: merge' or 'auto_merge_method: squash' instead.`;
-    }
-
-    if (
-      errorStr.includes("not authorized") ||
-      errorStr.includes("insufficient permissions")
-    ) {
-      return `Insufficient permissions to enable auto-merge. Ensure the GitHub token has 'contents: write' and 'pull-requests: write' permissions.`;
-    }
-
-    if (errorStr.includes("protected branch")) {
-      return `Branch protection rules prevent auto-merge. Check if the bot/user has merge permissions on protected branches.`;
-    }
-
-    if (
-      errorStr.includes("Pull request is in clean status") ||
-      errorStr.includes("clean status")
-    ) {
-      return `PR can be merged immediately, so auto-merge is not needed. Auto-merge only works when there are pending requirements (like required status checks or reviews).`;
-    }
-
-    // Generic fallback with some context
-    return `Auto-merge method '${mergeMethod}' failed. Check repository merge settings and permissions. Error: ${error.message}`;
   }
 }
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -21,6 +21,28 @@ type PRContent = {
   body: string;
 };
 
+/**
+ * Per-run context shared by every per-target backport.
+ *
+ * `workflow*` fields point at the repo where the action runs (and where the
+ * source PR lives — comments go here). `target*` fields point at the repo
+ * where backport branches and PRs are created — same as the workflow repo
+ * unless using the `downstream_repo` experimental config.
+ */
+type BackportContext = {
+  workflowOwner: string;
+  workflowRepo: string;
+  targetOwner: string;
+  targetRepo: string;
+  pullNumber: number;
+  runId: string;
+  runUrl: string;
+  remote: "origin" | "downstream";
+  commitShasToCherryPick: string[];
+  labelsToCopy: string[];
+  mainpr: PullRequest;
+};
+
 export type Config = {
   pwd: string;
   source_labels_pattern?: RegExp;
@@ -193,245 +215,29 @@ export class Backport {
         );
       }
 
+      const context: BackportContext = {
+        workflowOwner,
+        workflowRepo,
+        targetOwner,
+        targetRepo,
+        pullNumber: pull_number,
+        runId: this.github.getRunId(),
+        runUrl: this.github.getRunUrl(),
+        remote: this.getRemote(),
+        commitShasToCherryPick,
+        labelsToCopy,
+        mainpr,
+      };
+
       const successByTarget = new Map<string, boolean>();
       const createdPullRequestNumbers = new Array<number>();
       for (const targetBranch of target_branches) {
-        console.log(`Backporting to target branch '${targetBranch}...'`);
-
-        try {
-          await this.git.fetch(
-            targetBranch,
-            this.config.pwd,
-            1,
-            this.getRemote(),
-          );
-        } catch (error) {
-          if (error instanceof GitRefNotFoundError) {
-            const message = this.composeMessageForFetchTargetFailure(error.ref);
-            console.error(message);
-            successByTarget.set(targetBranch, false);
-            await this.github.createComment({
-              owner: workflowOwner,
-              repo: workflowRepo,
-              issue_number: pull_number,
-              body: message,
-            });
-            continue;
-          } else {
-            throw error;
-          }
-        }
-
-        try {
-          const branchname = utils.replacePlaceholders(
-            this.config.pull.branch_name,
-            mainpr,
-            targetBranch,
-          );
-
-          console.log(`Start backport to ${branchname}`);
-          try {
-            await this.git.checkout(
-              branchname,
-              `${this.getRemote()}/${targetBranch}`,
-              this.config.pwd,
-            );
-          } catch (error) {
-            const message = this.composeMessageForCheckoutFailure(
-              targetBranch,
-              branchname,
-              commitShasToCherryPick,
-            );
-            console.error(message);
-            successByTarget.set(targetBranch, false);
-            await this.github.createComment({
-              owner: workflowOwner,
-              repo: workflowRepo,
-              issue_number: pull_number,
-              body: message,
-            });
-            continue;
-          }
-
-          let uncommitedShas: string[] | null;
-
-          try {
-            uncommitedShas = await this.git.cherryPick(
-              commitShasToCherryPick,
-              this.config.experimental.conflict_resolution,
-              this.config.pwd,
-            );
-          } catch (error) {
-            const message = this.composeMessageForCherryPickFailure(
-              targetBranch,
-              branchname,
-              commitShasToCherryPick,
-            );
-            console.error(message);
-            successByTarget.set(targetBranch, false);
-            await this.github.createComment({
-              owner: workflowOwner,
-              repo: workflowRepo,
-              issue_number: pull_number,
-              body: message,
-            });
-            continue;
-          }
-
-          console.info(`Push branch to ${this.getRemote()}`);
-          try {
-            await this.git.push(
-              branchname,
-              this.getRemote(),
-              this.config.pwd,
-            );
-          } catch (pushError) {
-            if (!(pushError instanceof GitPushError)) throw pushError;
-            try {
-              // If the branch already exists, ignore the error and keep going.
-              console.info(
-                `Branch ${branchname} may already exist, fetching it instead to recover previous run`,
-              );
-              await this.git.fetch(
-                branchname,
-                this.config.pwd,
-                1,
-                this.getRemote(),
-              );
-              console.info(
-                `Previous branch successfully recovered, retrying PR creation`,
-              );
-              // note that the recovered branch is not guaranteed to be up-to-date
-            } catch {
-              // Fetching the branch failed as well, so report the original push error.
-              const message = this.composeMessageForGitPushFailure(
-                targetBranch,
-                pushError.exitCode,
-              );
-              console.error(message);
-              successByTarget.set(targetBranch, false);
-              await this.github.createComment({
-                owner: workflowOwner,
-                repo: workflowRepo,
-                issue_number: pull_number,
-                body: message,
-              });
-              continue;
-            }
-          }
-
-          console.info(`Create PR for ${branchname}`);
-          const { title, body } = this.composePRContent(targetBranch, mainpr);
-          let new_pr_response: CreatePullRequestResponse;
-          try {
-            new_pr_response = await this.github.createPR({
-              owner: targetOwner,
-              repo: targetRepo,
-              title,
-              body,
-              head: branchname,
-              base: targetBranch,
-              maintainer_can_modify: true,
-              draft: uncommitedShas !== null,
-            });
-          } catch (error) {
-            if (!(error instanceof RequestError)) throw error;
-
-            if (
-              error.status == 422 &&
-              (error.response?.data as any).errors.some((err: any) =>
-                err.message.startsWith("A pull request already exists for "),
-              )
-            ) {
-              console.info(`PR for ${branchname} already exists, skipping.`);
-              continue;
-            }
-
-            console.error(JSON.stringify(error.response?.data));
-            successByTarget.set(targetBranch, false);
-            const message = this.composeMessageForCreatePRFailed(error);
-            await this.github.createComment({
-              owner: workflowOwner,
-              repo: workflowRepo,
-              issue_number: pull_number,
-              body: message,
-            });
-            continue;
-          }
-          const new_pr = new_pr_response.data;
-
-          await postCreatePR(
-            this.github,
-            this.config,
-            new_pr.number,
-            mainpr,
-            labelsToCopy,
-            { owner: targetOwner, repo: targetRepo },
-            { owner: workflowOwner, repo: workflowRepo },
-          );
-
-          // post success message to original pr
-          {
-            const message =
-              uncommitedShas !== null
-                ? this.composeMessageForSuccessWithConflicts(
-                    new_pr.number,
-                    targetBranch,
-                    this.shouldUseDownstreamRepo()
-                      ? `${targetOwner}/${targetRepo}`
-                      : "",
-                    branchname,
-                    uncommitedShas,
-                    this.config.experimental.conflict_resolution,
-                  )
-                : this.composeMessageForSuccess(
-                    new_pr.number,
-                    targetBranch,
-                    this.shouldUseDownstreamRepo()
-                      ? `${targetOwner}/${targetRepo}`
-                      : "",
-                  );
-
-            successByTarget.set(targetBranch, true);
-            createdPullRequestNumbers.push(new_pr.number);
-            await this.github.createComment({
-              owner: workflowOwner,
-              repo: workflowRepo,
-              issue_number: pull_number,
-              body: message,
-            });
-          }
-          // post message to new pr to resolve conflict
-          if (uncommitedShas !== null) {
-            const message: string =
-              this.composeMessageToResolveCommittedConflicts(
-                targetBranch,
-                branchname,
-                uncommitedShas,
-                this.config.experimental.conflict_resolution,
-              );
-
-            await this.github.createComment({
-              owner: targetOwner,
-              repo: targetRepo,
-              issue_number: new_pr.number,
-              body: message,
-            });
-          }
-        } catch (error) {
-          if (error instanceof Error) {
-            console.error(error.message);
-            successByTarget.set(targetBranch, false);
-            await this.github.createComment({
-              owner: workflowOwner,
-              repo: workflowRepo,
-              issue_number: pull_number,
-              body: error.message,
-            });
-          } else {
-            throw error;
-          }
-        }
+        await this.backportToTarget(
+          targetBranch,
+          context,
+          successByTarget,
+          createdPullRequestNumbers,
+        );
       }
 
       this.createOutput(successByTarget, createdPullRequestNumbers);
@@ -451,6 +257,247 @@ export class Backport {
   private findTargetBranches(mainpr: PullRequest, config: Config): string[] {
     const labels = mainpr.labels.map((label) => label.name);
     return findTargetBranches(config, labels, mainpr.head.ref);
+  }
+
+  private async backportToTarget(
+    targetBranch: string,
+    context: BackportContext,
+    successByTarget: Map<string, boolean>,
+    createdPullRequestNumbers: number[],
+  ): Promise<void> {
+    const {
+      workflowOwner,
+      workflowRepo,
+      targetOwner,
+      targetRepo,
+      pullNumber,
+      remote,
+      commitShasToCherryPick,
+      labelsToCopy,
+      mainpr,
+    } = context;
+
+    console.log(`Backporting to target branch '${targetBranch}...'`);
+
+    try {
+      await this.git.fetch(targetBranch, this.config.pwd, 1, remote);
+    } catch (error) {
+      if (error instanceof GitRefNotFoundError) {
+        const message = this.composeMessageForFetchTargetFailure(error.ref);
+        console.error(message);
+        successByTarget.set(targetBranch, false);
+        await this.github.createComment({
+          owner: workflowOwner,
+          repo: workflowRepo,
+          issue_number: pullNumber,
+          body: message,
+        });
+        return;
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      const branchname = utils.replacePlaceholders(
+        this.config.pull.branch_name,
+        mainpr,
+        targetBranch,
+      );
+
+      console.log(`Start backport to ${branchname}`);
+      try {
+        await this.git.checkout(
+          branchname,
+          `${remote}/${targetBranch}`,
+          this.config.pwd,
+        );
+      } catch (error) {
+        const message = this.composeMessageForCheckoutFailure(
+          targetBranch,
+          branchname,
+          commitShasToCherryPick,
+        );
+        console.error(message);
+        successByTarget.set(targetBranch, false);
+        await this.github.createComment({
+          owner: workflowOwner,
+          repo: workflowRepo,
+          issue_number: pullNumber,
+          body: message,
+        });
+        return;
+      }
+
+      let uncommitedShas: string[] | null;
+
+      try {
+        uncommitedShas = await this.git.cherryPick(
+          commitShasToCherryPick,
+          this.config.experimental.conflict_resolution,
+          this.config.pwd,
+        );
+      } catch (error) {
+        const message = this.composeMessageForCherryPickFailure(
+          targetBranch,
+          branchname,
+          commitShasToCherryPick,
+        );
+        console.error(message);
+        successByTarget.set(targetBranch, false);
+        await this.github.createComment({
+          owner: workflowOwner,
+          repo: workflowRepo,
+          issue_number: pullNumber,
+          body: message,
+        });
+        return;
+      }
+
+      console.info(`Push branch to ${remote}`);
+      try {
+        await this.git.push(branchname, remote, this.config.pwd);
+      } catch (pushError) {
+        if (!(pushError instanceof GitPushError)) throw pushError;
+        try {
+          // If the branch already exists, ignore the error and keep going.
+          console.info(
+            `Branch ${branchname} may already exist, fetching it instead to recover previous run`,
+          );
+          await this.git.fetch(branchname, this.config.pwd, 1, remote);
+          console.info(
+            `Previous branch successfully recovered, retrying PR creation`,
+          );
+          // note that the recovered branch is not guaranteed to be up-to-date
+        } catch {
+          // Fetching the branch failed as well, so report the original push error.
+          const message = this.composeMessageForGitPushFailure(
+            targetBranch,
+            pushError.exitCode,
+          );
+          console.error(message);
+          successByTarget.set(targetBranch, false);
+          await this.github.createComment({
+            owner: workflowOwner,
+            repo: workflowRepo,
+            issue_number: pullNumber,
+            body: message,
+          });
+          return;
+        }
+      }
+
+      console.info(`Create PR for ${branchname}`);
+      const { title, body } = this.composePRContent(targetBranch, mainpr);
+      let new_pr_response: CreatePullRequestResponse;
+      try {
+        new_pr_response = await this.github.createPR({
+          owner: targetOwner,
+          repo: targetRepo,
+          title,
+          body,
+          head: branchname,
+          base: targetBranch,
+          maintainer_can_modify: true,
+          draft: uncommitedShas !== null,
+        });
+      } catch (error) {
+        if (!(error instanceof RequestError)) throw error;
+
+        if (
+          error.status == 422 &&
+          (error.response?.data as any).errors.some((err: any) =>
+            err.message.startsWith("A pull request already exists for "),
+          )
+        ) {
+          console.info(`PR for ${branchname} already exists, skipping.`);
+          return;
+        }
+
+        console.error(JSON.stringify(error.response?.data));
+        successByTarget.set(targetBranch, false);
+        const message = this.composeMessageForCreatePRFailed(error);
+        await this.github.createComment({
+          owner: workflowOwner,
+          repo: workflowRepo,
+          issue_number: pullNumber,
+          body: message,
+        });
+        return;
+      }
+      const new_pr = new_pr_response.data;
+
+      await postCreatePR(
+        this.github,
+        this.config,
+        new_pr.number,
+        mainpr,
+        labelsToCopy,
+        { owner: targetOwner, repo: targetRepo },
+        { owner: workflowOwner, repo: workflowRepo },
+      );
+
+      // post success message to original pr
+      {
+        const message =
+          uncommitedShas !== null
+            ? this.composeMessageForSuccessWithConflicts(
+                new_pr.number,
+                targetBranch,
+                this.shouldUseDownstreamRepo()
+                  ? `${targetOwner}/${targetRepo}`
+                  : "",
+                branchname,
+                uncommitedShas,
+                this.config.experimental.conflict_resolution,
+              )
+            : this.composeMessageForSuccess(
+                new_pr.number,
+                targetBranch,
+                this.shouldUseDownstreamRepo()
+                  ? `${targetOwner}/${targetRepo}`
+                  : "",
+              );
+
+        successByTarget.set(targetBranch, true);
+        createdPullRequestNumbers.push(new_pr.number);
+        await this.github.createComment({
+          owner: workflowOwner,
+          repo: workflowRepo,
+          issue_number: pullNumber,
+          body: message,
+        });
+      }
+      // post message to new pr to resolve conflict
+      if (uncommitedShas !== null) {
+        const message: string = this.composeMessageToResolveCommittedConflicts(
+          targetBranch,
+          branchname,
+          uncommitedShas,
+          this.config.experimental.conflict_resolution,
+        );
+
+        await this.github.createComment({
+          owner: targetOwner,
+          repo: targetRepo,
+          issue_number: new_pr.number,
+          body: message,
+        });
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(error.message);
+        successByTarget.set(targetBranch, false);
+        await this.github.createComment({
+          owner: workflowOwner,
+          repo: workflowRepo,
+          issue_number: pullNumber,
+          body: error.message,
+        });
+      } else {
+        throw error;
+      }
+    }
   }
 
   private composePRContent(target: string, main: PullRequest): PRContent {

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -8,7 +8,13 @@ import {
 } from "./github.js";
 import { GithubApi } from "./github.js";
 import { GitApi, GitRefNotFoundError } from "./git.js";
-import { GitPushError } from "./errors.js";
+import {
+  BackportError,
+  CheckoutError,
+  CherryPickError,
+  CreatePRError,
+  GitPushError,
+} from "./errors.js";
 import { postCreatePR } from "./pr-post-create.js";
 import {
   MergeCommitsNotAllowedError,
@@ -42,6 +48,38 @@ type BackportContext = {
   labelsToCopy: string[];
   mainpr: PullRequest;
 };
+
+/**
+ * Outcome of a single per-target backport attempt.
+ *
+ * `backportToTarget` returns one of these so that comment posting and
+ * bookkeeping can be done in `run()`, where they can also be replaced by
+ * the progressive summary comment in Phase 8c.
+ *
+ * Phase 8a moves this type to `errors.ts` so `comments.ts` can import it
+ * without depending on `backport.ts`.
+ */
+export type TargetResult =
+  | {
+      status: "success";
+      targetBranch: string;
+      newPrNumber: number;
+      branchname: string;
+    }
+  | {
+      status: "success_with_conflicts";
+      targetBranch: string;
+      newPrNumber: number;
+      branchname: string;
+      uncommittedShas: string[];
+    }
+  | { status: "skipped"; targetBranch: string; reason: string }
+  | {
+      status: "failed";
+      targetBranch: string;
+      error: BackportError | Error;
+      branchname?: string;
+    };
 
 export type Config = {
   pwd: string;
@@ -232,12 +270,19 @@ export class Backport {
       const successByTarget = new Map<string, boolean>();
       const createdPullRequestNumbers = new Array<number>();
       for (const targetBranch of target_branches) {
-        await this.backportToTarget(
-          targetBranch,
-          context,
-          successByTarget,
-          createdPullRequestNumbers,
-        );
+        const result = await this.backportToTarget(targetBranch, context);
+        await this.handleTargetResultLegacy(result, context);
+
+        if (result.status === "skipped") continue;
+
+        successByTarget.set(targetBranch, result.status !== "failed");
+
+        if (
+          result.status === "success" ||
+          result.status === "success_with_conflicts"
+        ) {
+          createdPullRequestNumbers.push(result.newPrNumber);
+        }
       }
 
       this.createOutput(successByTarget, createdPullRequestNumbers);
@@ -262,20 +307,9 @@ export class Backport {
   private async backportToTarget(
     targetBranch: string,
     context: BackportContext,
-    successByTarget: Map<string, boolean>,
-    createdPullRequestNumbers: number[],
-  ): Promise<void> {
-    const {
-      workflowOwner,
-      workflowRepo,
-      targetOwner,
-      targetRepo,
-      pullNumber,
-      remote,
-      commitShasToCherryPick,
-      labelsToCopy,
-      mainpr,
-    } = context;
+  ): Promise<TargetResult> {
+    const { targetOwner, targetRepo, remote, commitShasToCherryPick, mainpr } =
+      context;
 
     console.log(`Backporting to target branch '${targetBranch}...'`);
 
@@ -283,28 +317,18 @@ export class Backport {
       await this.git.fetch(targetBranch, this.config.pwd, 1, remote);
     } catch (error) {
       if (error instanceof GitRefNotFoundError) {
-        const message = this.composeMessageForFetchTargetFailure(error.ref);
-        console.error(message);
-        successByTarget.set(targetBranch, false);
-        await this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pullNumber,
-          body: message,
-        });
-        return;
-      } else {
-        throw error;
+        return { status: "failed", targetBranch, error };
       }
+      throw error;
     }
 
-    try {
-      const branchname = utils.replacePlaceholders(
-        this.config.pull.branch_name,
-        mainpr,
-        targetBranch,
-      );
+    const branchname = utils.replacePlaceholders(
+      this.config.pull.branch_name,
+      mainpr,
+      targetBranch,
+    );
 
+    try {
       console.log(`Start backport to ${branchname}`);
       try {
         await this.git.checkout(
@@ -313,45 +337,45 @@ export class Backport {
           this.config.pwd,
         );
       } catch (error) {
-        const message = this.composeMessageForCheckoutFailure(
+        const message =
+          error instanceof Error
+            ? error.message
+            : `git checkout ${branchname} failed`;
+        return {
+          status: "failed",
           targetBranch,
           branchname,
-          commitShasToCherryPick,
-        );
-        console.error(message);
-        successByTarget.set(targetBranch, false);
-        await this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pullNumber,
-          body: message,
-        });
-        return;
+          error: new CheckoutError(
+            message,
+            branchname,
+            commitShasToCherryPick,
+          ),
+        };
       }
 
-      let uncommitedShas: string[] | null;
+      let uncommittedShas: string[] | null;
 
       try {
-        uncommitedShas = await this.git.cherryPick(
+        uncommittedShas = await this.git.cherryPick(
           commitShasToCherryPick,
           this.config.experimental.conflict_resolution,
           this.config.pwd,
         );
       } catch (error) {
-        const message = this.composeMessageForCherryPickFailure(
+        const message =
+          error instanceof Error
+            ? error.message
+            : `cherry-pick failed for ${commitShasToCherryPick.join(", ")}`;
+        return {
+          status: "failed",
           targetBranch,
           branchname,
-          commitShasToCherryPick,
-        );
-        console.error(message);
-        successByTarget.set(targetBranch, false);
-        await this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pullNumber,
-          body: message,
-        });
-        return;
+          error: new CherryPickError(
+            message,
+            branchname,
+            commitShasToCherryPick,
+          ),
+        };
       }
 
       console.info(`Push branch to ${remote}`);
@@ -371,19 +395,12 @@ export class Backport {
           // note that the recovered branch is not guaranteed to be up-to-date
         } catch {
           // Fetching the branch failed as well, so report the original push error.
-          const message = this.composeMessageForGitPushFailure(
+          return {
+            status: "failed",
             targetBranch,
-            pushError.exitCode,
-          );
-          console.error(message);
-          successByTarget.set(targetBranch, false);
-          await this.github.createComment({
-            owner: workflowOwner,
-            repo: workflowRepo,
-            issue_number: pullNumber,
-            body: message,
-          });
-          return;
+            branchname,
+            error: pushError,
+          };
         }
       }
 
@@ -399,7 +416,7 @@ export class Backport {
           head: branchname,
           base: targetBranch,
           maintainer_can_modify: true,
-          draft: uncommitedShas !== null,
+          draft: uncommittedShas !== null,
         });
       } catch (error) {
         if (!(error instanceof RequestError)) throw error;
@@ -411,19 +428,24 @@ export class Backport {
           )
         ) {
           console.info(`PR for ${branchname} already exists, skipping.`);
-          return;
+          return {
+            status: "skipped",
+            targetBranch,
+            reason: "PR already exists",
+          };
         }
 
         console.error(JSON.stringify(error.response?.data));
-        successByTarget.set(targetBranch, false);
-        const message = this.composeMessageForCreatePRFailed(error);
-        await this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pullNumber,
-          body: message,
-        });
-        return;
+        return {
+          status: "failed",
+          targetBranch,
+          branchname,
+          error: new CreatePRError(
+            error.message,
+            error.status,
+            JSON.stringify(error.response?.data),
+          ),
+        };
       }
       const new_pr = new_pr_response.data;
 
@@ -432,72 +454,140 @@ export class Backport {
         this.config,
         new_pr.number,
         mainpr,
-        labelsToCopy,
+        context.labelsToCopy,
         { owner: targetOwner, repo: targetRepo },
-        { owner: workflowOwner, repo: workflowRepo },
+        { owner: context.workflowOwner, repo: context.workflowRepo },
       );
 
-      // post success message to original pr
-      {
-        const message =
-          uncommitedShas !== null
-            ? this.composeMessageForSuccessWithConflicts(
-                new_pr.number,
-                targetBranch,
-                this.shouldUseDownstreamRepo()
-                  ? `${targetOwner}/${targetRepo}`
-                  : "",
-                branchname,
-                uncommitedShas,
-                this.config.experimental.conflict_resolution,
-              )
-            : this.composeMessageForSuccess(
-                new_pr.number,
-                targetBranch,
-                this.shouldUseDownstreamRepo()
-                  ? `${targetOwner}/${targetRepo}`
-                  : "",
-              );
-
-        successByTarget.set(targetBranch, true);
-        createdPullRequestNumbers.push(new_pr.number);
-        await this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pullNumber,
-          body: message,
-        });
-      }
-      // post message to new pr to resolve conflict
-      if (uncommitedShas !== null) {
-        const message: string = this.composeMessageToResolveCommittedConflicts(
+      if (uncommittedShas !== null) {
+        return {
+          status: "success_with_conflicts",
           targetBranch,
+          newPrNumber: new_pr.number,
           branchname,
-          uncommitedShas,
-          this.config.experimental.conflict_resolution,
-        );
-
-        await this.github.createComment({
-          owner: targetOwner,
-          repo: targetRepo,
-          issue_number: new_pr.number,
-          body: message,
-        });
+          uncommittedShas,
+        };
       }
+      return {
+        status: "success",
+        targetBranch,
+        newPrNumber: new_pr.number,
+        branchname,
+      };
     } catch (error) {
       if (error instanceof Error) {
         console.error(error.message);
-        successByTarget.set(targetBranch, false);
-        await this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pullNumber,
-          body: error.message,
-        });
-      } else {
-        throw error;
+        console.error(error.stack ?? "");
+        return { status: "failed", targetBranch, branchname, error };
       }
+      throw error;
     }
+  }
+
+  /**
+   * Posts the per-target comments matching the existing legacy behavior:
+   *   - failed: post the failure message on the source PR
+   *   - success / success_with_conflicts: post the success message on the
+   *     source PR; for conflicts, also post the recovery instructions on
+   *     the new backport PR
+   *   - skipped: no comment (matches the previous `continue` behavior)
+   *
+   * Phase 8c will replace this with the progressive summary comment flow
+   * when `comment_style: summary` is enabled.
+   */
+  private async handleTargetResultLegacy(
+    result: TargetResult,
+    context: BackportContext,
+  ): Promise<void> {
+    const { workflowOwner, workflowRepo, targetOwner, targetRepo, pullNumber } =
+      context;
+
+    if (result.status === "skipped") return;
+
+    if (result.status === "failed") {
+      const message = this.composeFailureMessage(result, context);
+      console.error(message);
+      await this.github.createComment({
+        owner: workflowOwner,
+        repo: workflowRepo,
+        issue_number: pullNumber,
+        body: message,
+      });
+      return;
+    }
+
+    const { targetBranch, newPrNumber, branchname } = result;
+    const downstream = this.shouldUseDownstreamRepo()
+      ? `${targetOwner}/${targetRepo}`
+      : "";
+
+    const successMessage =
+      result.status === "success_with_conflicts"
+        ? this.composeMessageForSuccessWithConflicts(
+            newPrNumber,
+            targetBranch,
+            downstream,
+            branchname,
+            result.uncommittedShas,
+            this.config.experimental.conflict_resolution,
+          )
+        : this.composeMessageForSuccess(newPrNumber, targetBranch, downstream);
+
+    await this.github.createComment({
+      owner: workflowOwner,
+      repo: workflowRepo,
+      issue_number: pullNumber,
+      body: successMessage,
+    });
+
+    if (result.status === "success_with_conflicts") {
+      const conflictMessage = this.composeMessageToResolveCommittedConflicts(
+        targetBranch,
+        branchname,
+        result.uncommittedShas,
+        this.config.experimental.conflict_resolution,
+      );
+      await this.github.createComment({
+        owner: targetOwner,
+        repo: targetRepo,
+        issue_number: newPrNumber,
+        body: conflictMessage,
+      });
+    }
+  }
+
+  private composeFailureMessage(
+    result: Extract<TargetResult, { status: "failed" }>,
+    context: BackportContext,
+  ): string {
+    const { targetBranch, error } = result;
+    if (error instanceof GitRefNotFoundError) {
+      return this.composeMessageForFetchTargetFailure(error.ref);
+    }
+    if (error instanceof CheckoutError) {
+      return this.composeMessageForCheckoutFailure(
+        targetBranch,
+        error.branch,
+        error.commits,
+      );
+    }
+    if (error instanceof CherryPickError) {
+      return this.composeMessageForCherryPickFailure(
+        targetBranch,
+        error.branch,
+        error.commits,
+      );
+    }
+    if (error instanceof GitPushError) {
+      return this.composeMessageForGitPushFailure(targetBranch, error.exitCode);
+    }
+    if (error instanceof CreatePRError) {
+      return dedent`Backport branch created but failed to create PR.
+                    Request to create PR rejected with status ${error.status}.
+
+                    (see action log for full response)`;
+    }
+    return error.message;
   }
 
   private composePRContent(target: string, main: PullRequest): PRContent {
@@ -612,13 +702,6 @@ export class Backport {
   ): string {
     //TODO better error messages depending on exit code
     return dedent`Git push to origin failed for ${target} with exitcode ${exitcode}`;
-  }
-
-  private composeMessageForCreatePRFailed(error: RequestError): string {
-    return dedent`Backport branch created but failed to create PR.
-                Request to create PR rejected with status ${error.status}.
-
-                (see action log for full response)`;
   }
 
   private composeMessageForSuccess(

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -98,19 +98,22 @@ export class Backport {
     try {
       const payload = this.github.getPayload();
 
+      // Repo where the workflow runs — used for commenting on the source PR.
       const workflowOwner = this.github.getRepo().owner;
-      const owner =
+      const workflowRepo =
+        payload.repository?.name ?? this.github.getRepo().repo;
+
+      // Repo where backport branches and PRs are created — same as workflow
+      // repo unless using the downstream_repo experimental config.
+      const targetOwner =
         this.shouldUseDownstreamRepo() && this.downstreamOwner // if undefined, use owner of workflow
           ? this.downstreamOwner
           : workflowOwner;
-
-      const workflowRepo =
-        payload.repository?.name ?? this.github.getRepo().repo;
-      const repo = this.shouldUseDownstreamRepo()
+      const targetRepo = this.shouldUseDownstreamRepo()
         ? this.downstreamRepo
         : workflowRepo;
 
-      if (repo === undefined) throw new Error("No repository defined!");
+      if (targetRepo === undefined) throw new Error("No repository defined!");
 
       const pull_number =
         this.config.source_pr_number === undefined
@@ -260,21 +263,31 @@ export class Backport {
       );
 
       if (this.shouldUseDownstreamRepo()) {
-        await this.git.remoteAdd(this.config.pwd, "downstream", owner, repo);
+        await this.git.remoteAdd(
+          this.config.pwd,
+          "downstream",
+          targetOwner,
+          targetRepo,
+        );
       }
 
       const successByTarget = new Map<string, boolean>();
       const createdPullRequestNumbers = new Array<number>();
-      for (const target of target_branches) {
-        console.log(`Backporting to target branch '${target}...'`);
+      for (const targetBranch of target_branches) {
+        console.log(`Backporting to target branch '${targetBranch}...'`);
 
         try {
-          await this.git.fetch(target, this.config.pwd, 1, this.getRemote());
+          await this.git.fetch(
+            targetBranch,
+            this.config.pwd,
+            1,
+            this.getRemote(),
+          );
         } catch (error) {
           if (error instanceof GitRefNotFoundError) {
             const message = this.composeMessageForFetchTargetFailure(error.ref);
             console.error(message);
-            successByTarget.set(target, false);
+            successByTarget.set(targetBranch, false);
             await this.github.createComment({
               owner: workflowOwner,
               repo: workflowRepo,
@@ -291,24 +304,24 @@ export class Backport {
           const branchname = utils.replacePlaceholders(
             this.config.pull.branch_name,
             mainpr,
-            target,
+            targetBranch,
           );
 
           console.log(`Start backport to ${branchname}`);
           try {
             await this.git.checkout(
               branchname,
-              `${this.getRemote()}/${target}`,
+              `${this.getRemote()}/${targetBranch}`,
               this.config.pwd,
             );
           } catch (error) {
             const message = this.composeMessageForCheckoutFailure(
-              target,
+              targetBranch,
               branchname,
               commitShasToCherryPick,
             );
             console.error(message);
-            successByTarget.set(target, false);
+            successByTarget.set(targetBranch, false);
             await this.github.createComment({
               owner: workflowOwner,
               repo: workflowRepo,
@@ -328,12 +341,12 @@ export class Backport {
             );
           } catch (error) {
             const message = this.composeMessageForCherryPickFailure(
-              target,
+              targetBranch,
               branchname,
               commitShasToCherryPick,
             );
             console.error(message);
-            successByTarget.set(target, false);
+            successByTarget.set(targetBranch, false);
             await this.github.createComment({
               owner: workflowOwner,
               repo: workflowRepo,
@@ -368,11 +381,11 @@ export class Backport {
             } catch {
               // Fetching the branch failed as well, so report the original push error.
               const message = this.composeMessageForGitPushFailure(
-                target,
+                targetBranch,
                 pushExitCode,
               );
               console.error(message);
-              successByTarget.set(target, false);
+              successByTarget.set(targetBranch, false);
               await this.github.createComment({
                 owner: workflowOwner,
                 repo: workflowRepo,
@@ -384,16 +397,16 @@ export class Backport {
           }
 
           console.info(`Create PR for ${branchname}`);
-          const { title, body } = this.composePRContent(target, mainpr);
+          const { title, body } = this.composePRContent(targetBranch, mainpr);
           let new_pr_response: CreatePullRequestResponse;
           try {
             new_pr_response = await this.github.createPR({
-              owner,
-              repo,
+              owner: targetOwner,
+              repo: targetRepo,
               title,
               body,
               head: branchname,
-              base: target,
+              base: targetBranch,
               maintainer_can_modify: true,
               draft: uncommitedShas !== null,
             });
@@ -411,7 +424,7 @@ export class Backport {
             }
 
             console.error(JSON.stringify(error.response?.data));
-            successByTarget.set(target, false);
+            successByTarget.set(targetBranch, false);
             const message = this.composeMessageForCreatePRFailed(error);
             await this.github.createComment({
               owner: workflowOwner,
@@ -443,8 +456,8 @@ export class Backport {
               console.info("Setting assignees " + assignees);
               try {
                 await this.github.addAssignees(new_pr.number, assignees, {
-                  owner,
-                  repo,
+                  owner: targetOwner,
+                  repo: targetRepo,
                 });
               } catch (error) {
                 if (!(error instanceof RequestError)) throw error;
@@ -485,8 +498,8 @@ export class Backport {
             if (reviewers.length > 0) {
               console.info("Setting reviewers " + reviewers);
               const reviewRequest = {
-                owner,
-                repo,
+                owner: targetOwner,
+                repo: targetRepo,
                 pull_number: new_pr.number,
                 reviewers: reviewers,
               };
@@ -506,8 +519,8 @@ export class Backport {
             if (reviewers.length > 0) {
               console.info("Setting reviewers " + reviewers);
               const reviewRequest = {
-                owner,
-                repo,
+                owner: targetOwner,
+                repo: targetRepo,
                 pull_number: new_pr.number,
                 reviewers: reviewers,
               };
@@ -527,8 +540,8 @@ export class Backport {
           if (labels.length > 0) {
             try {
               await this.github.labelPR(new_pr.number, labels, {
-                owner,
-                repo,
+                owner: targetOwner,
+                repo: targetRepo,
               });
             } catch (error) {
               if (!(error instanceof RequestError)) throw error;
@@ -542,8 +555,8 @@ export class Backport {
             console.info("Setting " + author + " as assignee");
             try {
               await this.github.addAssignees(new_pr.number, [author], {
-                owner,
-                repo,
+                owner: targetOwner,
+                repo: targetRepo,
               });
             } catch (error) {
               if (!(error instanceof RequestError)) throw error;
@@ -556,8 +569,8 @@ export class Backport {
             console.info("Requesting review from " + author);
             try {
               await this.github.requestReviewers({
-                owner,
-                repo,
+                owner: targetOwner,
+                repo: targetRepo,
                 pull_number: new_pr.number,
                 reviewers: [author],
               });
@@ -572,8 +585,8 @@ export class Backport {
             console.info("Adding reviewers: " + addedReviewers);
             try {
               await this.github.requestReviewers({
-                owner,
-                repo,
+                owner: targetOwner,
+                repo: targetRepo,
                 pull_number: new_pr.number,
                 reviewers: addedReviewers,
               });
@@ -590,8 +603,8 @@ export class Backport {
             console.info("Adding team reviewers: " + addedTeamReviewers);
             try {
               await this.github.requestReviewers({
-                owner,
-                repo,
+                owner: targetOwner,
+                repo: targetRepo,
                 pull_number: new_pr.number,
                 reviewers: [],
                 team_reviewers: addedTeamReviewers,
@@ -610,8 +623,8 @@ export class Backport {
               await this.github.enableAutoMerge(
                 new_pr.number,
                 {
-                  owner,
-                  repo,
+                  owner: targetOwner,
+                  repo: targetRepo,
                 },
                 this.config.auto_merge_method,
               );
@@ -643,19 +656,23 @@ export class Backport {
               uncommitedShas !== null
                 ? this.composeMessageForSuccessWithConflicts(
                     new_pr.number,
-                    target,
-                    this.shouldUseDownstreamRepo() ? `${owner}/${repo}` : "",
+                    targetBranch,
+                    this.shouldUseDownstreamRepo()
+                      ? `${targetOwner}/${targetRepo}`
+                      : "",
                     branchname,
                     uncommitedShas,
                     this.config.experimental.conflict_resolution,
                   )
                 : this.composeMessageForSuccess(
                     new_pr.number,
-                    target,
-                    this.shouldUseDownstreamRepo() ? `${owner}/${repo}` : "",
+                    targetBranch,
+                    this.shouldUseDownstreamRepo()
+                      ? `${targetOwner}/${targetRepo}`
+                      : "",
                   );
 
-            successByTarget.set(target, true);
+            successByTarget.set(targetBranch, true);
             createdPullRequestNumbers.push(new_pr.number);
             await this.github.createComment({
               owner: workflowOwner,
@@ -668,15 +685,15 @@ export class Backport {
           if (uncommitedShas !== null) {
             const message: string =
               this.composeMessageToResolveCommittedConflicts(
-                target,
+                targetBranch,
                 branchname,
                 uncommitedShas,
                 this.config.experimental.conflict_resolution,
               );
 
             await this.github.createComment({
-              owner,
-              repo,
+              owner: targetOwner,
+              repo: targetRepo,
               issue_number: new_pr.number,
               body: message,
             });
@@ -684,7 +701,7 @@ export class Backport {
         } catch (error) {
           if (error instanceof Error) {
             console.error(error.message);
-            successByTarget.set(target, false);
+            successByTarget.set(targetBranch, false);
             await this.github.createComment({
               owner: workflowOwner,
               repo: workflowRepo,

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -8,6 +8,7 @@ import {
 } from "./github.js";
 import { GithubApi } from "./github.js";
 import { GitApi, GitRefNotFoundError } from "./git.js";
+import { GitPushError } from "./errors.js";
 import { postCreatePR } from "./pr-post-create.js";
 import {
   MergeCommitsNotAllowedError,
@@ -278,12 +279,14 @@ export class Backport {
           }
 
           console.info(`Push branch to ${this.getRemote()}`);
-          const pushExitCode = await this.git.push(
-            branchname,
-            this.getRemote(),
-            this.config.pwd,
-          );
-          if (pushExitCode != 0) {
+          try {
+            await this.git.push(
+              branchname,
+              this.getRemote(),
+              this.config.pwd,
+            );
+          } catch (pushError) {
+            if (!(pushError instanceof GitPushError)) throw pushError;
             try {
               // If the branch already exists, ignore the error and keep going.
               console.info(
@@ -303,7 +306,7 @@ export class Backport {
               // Fetching the branch failed as well, so report the original push error.
               const message = this.composeMessageForGitPushFailure(
                 targetBranch,
-                pushExitCode,
+                pushError.exitCode,
               );
               console.error(message);
               successByTarget.set(targetBranch, false);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,68 @@
+/**
+ * Typed error classes for per-target backport failures.
+ *
+ * Each subclass carries the structured data the comment formatter (Phase 8a)
+ * needs to render actionable recovery instructions for the user.
+ */
+
+export class BackportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BackportError";
+  }
+}
+
+export class CheckoutError extends BackportError {
+  branch: string;
+  commits: string[];
+
+  constructor(message: string, branch: string, commits: string[]) {
+    super(message);
+    this.name = "CheckoutError";
+    this.branch = branch;
+    this.commits = commits;
+  }
+}
+
+export class CherryPickError extends BackportError {
+  branch: string;
+  commits: string[];
+
+  constructor(message: string, branch: string, commits: string[]) {
+    super(message);
+    this.name = "CherryPickError";
+    this.branch = branch;
+    this.commits = commits;
+  }
+}
+
+export class GitPushError extends BackportError {
+  branch: string;
+  remote: string;
+  exitCode: number;
+
+  constructor(
+    message: string,
+    branch: string,
+    remote: string,
+    exitCode: number,
+  ) {
+    super(message);
+    this.name = "GitPushError";
+    this.branch = branch;
+    this.remote = remote;
+    this.exitCode = exitCode;
+  }
+}
+
+export class CreatePRError extends BackportError {
+  status: number;
+  responseMessage?: string;
+
+  constructor(message: string, status: number, responseMessage?: string) {
+    super(message);
+    this.name = "CreatePRError";
+    this.status = status;
+    this.responseMessage = responseMessage;
+  }
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,9 +1,12 @@
 import { ExecOptions, getExecOutput } from "@actions/exec";
 
-export class GitRefNotFoundError extends Error {
+import { BackportError, GitPushError } from "./errors.js";
+
+export class GitRefNotFoundError extends BackportError {
   ref: string;
   constructor(message: string, ref: string) {
     super(message);
+    this.name = "GitRefNotFoundError";
     this.ref = ref;
   }
 }
@@ -23,7 +26,7 @@ export interface GitApi {
   ): Promise<void>;
   findCommitsInRange(range: string, pwd: string): Promise<string[]>;
   findMergeCommits(commitShas: string[], pwd: string): Promise<string[]>;
-  push(branchname: string, remote: string, pwd: string): Promise<number>;
+  push(branchname: string, remote: string, pwd: string): Promise<void>;
   checkout(branch: string, start: string, pwd: string): Promise<void>;
   cherryPick(
     commitShas: string[],
@@ -160,7 +163,14 @@ export class Git implements GitApi {
       ["--set-upstream", remote, branchname],
       pwd,
     );
-    return exitCode;
+    if (exitCode !== 0) {
+      throw new GitPushError(
+        `'git push --set-upstream ${remote} ${branchname}' failed with exit code ${exitCode}`,
+        branchname,
+        remote,
+        exitCode,
+      );
+    }
   }
 
   public async checkout(branch: string, start: string, pwd: string) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -14,6 +14,8 @@ export interface GithubApi {
   getRepo(): Repo;
   getPayload(): Payload;
   getPullNumber(): number;
+  getRunId(): string;
+  getRunUrl(): string;
   createComment(comment: Comment): Promise<{}>;
   getPullRequest(pull_number: number): Promise<PullRequest>;
   isMerged(pull: PullRequest): Promise<boolean>;
@@ -73,6 +75,17 @@ export class Github implements GithubApi {
     // if the pr is not part of the payload
     // the number can be taken from the issue
     return this.#context.issue.number;
+  }
+
+  public getRunId(): string {
+    return process.env.GITHUB_RUN_ID ?? "";
+  }
+
+  public getRunUrl(): string {
+    const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+    const repository = process.env.GITHUB_REPOSITORY ?? "";
+    const runId = this.getRunId();
+    return `${serverUrl}/${repository}/actions/runs/${runId}`;
   }
 
   public async createComment(comment: Comment) {

--- a/src/pr-post-create.ts
+++ b/src/pr-post-create.ts
@@ -1,0 +1,259 @@
+import type { Config } from "./backport.js";
+import {
+  GithubApi,
+  PullRequest,
+  RequestError,
+} from "./github.js";
+
+/**
+ * Performs the post-PR-creation side-effects: copying milestones, assignees,
+ * reviewers, labels, and enabling auto-merge.
+ *
+ * Each side-effect is best-effort — a `RequestError` is logged and ignored so
+ * that one failure doesn't block the others (the PR has already been created).
+ * Non-`RequestError` failures propagate to the caller.
+ */
+export async function postCreatePR(
+  github: GithubApi,
+  config: Config,
+  newPrNumber: number,
+  mainpr: PullRequest,
+  labelsToCopy: string[],
+  targetRepo: { owner: string; repo: string },
+  workflowRepo: { owner: string; repo: string },
+): Promise<void> {
+  if (config.copy_milestone == true) {
+    const milestone = mainpr.milestone?.number;
+    if (milestone) {
+      console.info("Setting milestone to " + milestone);
+      try {
+        await github.setMilestone(newPrNumber, milestone);
+      } catch (error) {
+        if (!(error instanceof RequestError)) throw error;
+        console.error(JSON.stringify(error.response));
+      }
+    }
+  }
+
+  if (config.copy_assignees == true) {
+    const assignees = mainpr.assignees?.map((label) => label.login) ?? [];
+    if (assignees.length > 0) {
+      console.info("Setting assignees " + assignees);
+      try {
+        await github.addAssignees(newPrNumber, assignees, targetRepo);
+      } catch (error) {
+        if (!(error instanceof RequestError)) throw error;
+        console.error(JSON.stringify(error.response));
+      }
+    }
+  }
+
+  if (config.copy_all_reviewers == true) {
+    const requestedReviewers =
+      mainpr.requested_reviewers?.map((reviewer) => reviewer.login) ?? [];
+
+    let submittedReviewers: string[] = [];
+    try {
+      const { data: reviews } = await github.listReviews(
+        workflowRepo.owner,
+        workflowRepo.repo,
+        mainpr.number,
+      );
+
+      submittedReviewers = [
+        ...new Set(
+          reviews
+            .map((review) => review.user?.login)
+            .filter((login): login is string => Boolean(login)),
+        ),
+      ];
+    } catch (error) {
+      if (!(error instanceof RequestError)) throw error;
+      console.error(JSON.stringify(error.response));
+    }
+
+    const reviewers = [
+      ...new Set([...requestedReviewers, ...submittedReviewers]),
+    ];
+
+    if (reviewers.length > 0) {
+      console.info("Setting reviewers " + reviewers);
+      try {
+        await github.requestReviewers({
+          owner: targetRepo.owner,
+          repo: targetRepo.repo,
+          pull_number: newPrNumber,
+          reviewers: reviewers,
+        });
+      } catch (error) {
+        if (!(error instanceof RequestError)) throw error;
+        console.error(JSON.stringify(error.response));
+      }
+    }
+  }
+
+  if (config.copy_requested_reviewers == true) {
+    const reviewers =
+      mainpr.requested_reviewers?.map((reviewer) => reviewer.login) ?? [];
+    if (reviewers.length > 0) {
+      console.info("Setting reviewers " + reviewers);
+      try {
+        await github.requestReviewers({
+          owner: targetRepo.owner,
+          repo: targetRepo.repo,
+          pull_number: newPrNumber,
+          reviewers: reviewers,
+        });
+      } catch (error) {
+        if (!(error instanceof RequestError)) throw error;
+        console.error(JSON.stringify(error.response));
+      }
+    }
+  }
+
+  // Combine the labels to be copied with the static labels and deduplicate them using a Set
+  const labels = [...new Set([...labelsToCopy, ...config.add_labels])];
+  if (labels.length > 0) {
+    try {
+      await github.labelPR(newPrNumber, labels, targetRepo);
+    } catch (error) {
+      if (!(error instanceof RequestError)) throw error;
+      console.error(JSON.stringify(error.response));
+      // The PR was still created so let's still comment on the original.
+    }
+  }
+
+  if (config.add_author_as_assignee == true) {
+    const author = mainpr.user.login;
+    console.info("Setting " + author + " as assignee");
+    try {
+      await github.addAssignees(newPrNumber, [author], targetRepo);
+    } catch (error) {
+      if (!(error instanceof RequestError)) throw error;
+      console.error(JSON.stringify(error.response));
+    }
+  }
+
+  if (config.add_author_as_reviewer == true) {
+    const author = mainpr.user.login;
+    console.info("Requesting review from " + author);
+    try {
+      await github.requestReviewers({
+        owner: targetRepo.owner,
+        repo: targetRepo.repo,
+        pull_number: newPrNumber,
+        reviewers: [author],
+      });
+    } catch (error) {
+      if (!(error instanceof RequestError)) throw error;
+      console.error(JSON.stringify(error.response));
+    }
+  }
+
+  const addedReviewers = [...new Set(config.add_reviewers)];
+  if (addedReviewers.length > 0) {
+    console.info("Adding reviewers: " + addedReviewers);
+    try {
+      await github.requestReviewers({
+        owner: targetRepo.owner,
+        repo: targetRepo.repo,
+        pull_number: newPrNumber,
+        reviewers: addedReviewers,
+      });
+    } catch (error) {
+      if (!(error instanceof RequestError)) throw error;
+      console.error(JSON.stringify(error.response));
+    }
+  }
+
+  const addedTeamReviewers = [...new Set(config.add_team_reviewers)];
+  if (addedTeamReviewers.length > 0) {
+    console.info("Adding team reviewers: " + addedTeamReviewers);
+    try {
+      await github.requestReviewers({
+        owner: targetRepo.owner,
+        repo: targetRepo.repo,
+        pull_number: newPrNumber,
+        reviewers: [],
+        team_reviewers: addedTeamReviewers,
+      } as any);
+    } catch (error) {
+      if (!(error instanceof RequestError)) throw error;
+      console.error(JSON.stringify(error.response));
+    }
+  }
+
+  if (config.auto_merge_enabled === true) {
+    console.info("Attempting to enable auto-merge for PR #" + newPrNumber);
+    try {
+      await github.enableAutoMerge(
+        newPrNumber,
+        targetRepo,
+        config.auto_merge_method,
+      );
+      console.info("Successfully enabled auto-merge for PR #" + newPrNumber);
+    } catch (error) {
+      if (!(error instanceof RequestError)) throw error;
+
+      // Handle auto-merge failures gracefully
+      const errorMessage = getAutoMergeErrorMessage(
+        error,
+        config.auto_merge_method,
+      );
+      console.warn(
+        `Failed to enable auto-merge for PR #${newPrNumber}: ${errorMessage}`,
+      );
+      console.warn(
+        "The backport PR was created successfully, but auto-merge could not be enabled.",
+      );
+    }
+  }
+}
+
+function getAutoMergeErrorMessage(
+  error: RequestError,
+  mergeMethod: string,
+): string {
+  const errorStr = JSON.stringify(error.response?.data) || error.message;
+
+  // Check for common auto-merge error scenarios
+  if (errorStr.includes("auto-merge") && errorStr.includes("not allowed")) {
+    return `Repository does not have "Allow auto-merge" enabled. Please enable it in repository Settings > General > Pull Requests.`;
+  }
+
+  if (
+    errorStr.includes("merge commits are not allowed") ||
+    errorStr.includes("Merge method merge commits are not allowed")
+  ) {
+    return `Repository does not allow merge commits. Try using 'auto_merge_method: squash' or 'auto_merge_method: rebase' instead.`;
+  }
+
+  if (errorStr.includes("squash") && errorStr.includes("not allowed")) {
+    return `Repository does not allow squash merging. Try using 'auto_merge_method: merge' or 'auto_merge_method: rebase' instead.`;
+  }
+
+  if (errorStr.includes("rebase") && errorStr.includes("not allowed")) {
+    return `Repository does not allow rebase merging. Try using 'auto_merge_method: merge' or 'auto_merge_method: squash' instead.`;
+  }
+
+  if (
+    errorStr.includes("not authorized") ||
+    errorStr.includes("insufficient permissions")
+  ) {
+    return `Insufficient permissions to enable auto-merge. Ensure the GitHub token has 'contents: write' and 'pull-requests: write' permissions.`;
+  }
+
+  if (errorStr.includes("protected branch")) {
+    return `Branch protection rules prevent auto-merge. Check if the bot/user has merge permissions on protected branches.`;
+  }
+
+  if (
+    errorStr.includes("Pull request is in clean status") ||
+    errorStr.includes("clean status")
+  ) {
+    return `PR can be merged immediately, so auto-merge is not needed. Auto-merge only works when there are pending requirements (like required status checks or reviews).`;
+  }
+
+  // Generic fallback with some context
+  return `Auto-merge method '${mergeMethod}' failed. Check repository merge settings and permissions. Error: ${error.message}`;
+}

--- a/src/pr-post-create.ts
+++ b/src/pr-post-create.ts
@@ -1,9 +1,5 @@
 import type { Config } from "./backport.js";
-import {
-  GithubApi,
-  PullRequest,
-  RequestError,
-} from "./github.js";
+import { GithubApi, PullRequest, RequestError } from "./github.js";
 
 /**
  * Performs the post-PR-creation side-effects: copying milestones, assignees,

--- a/src/resolve-commits.ts
+++ b/src/resolve-commits.ts
@@ -75,7 +75,10 @@ export async function resolveCommitsToCherryPick(
           mainpr.commits + 1, // +1 in case this concerns a shallowly cloned repo
         );
         const range = `${merge_commit_sha}~${mainpr.commits}..${merge_commit_sha}`;
-        commitShasToCherryPick = await git.findCommitsInRange(range, config.pwd);
+        commitShasToCherryPick = await git.findCommitsInRange(
+          range,
+          config.pwd,
+        );
         break;
       case MergeStrategy.MERGECOMMIT:
         commitShasToCherryPick = commitShas;
@@ -103,17 +106,11 @@ export async function resolveCommitsToCherryPick(
   );
   console.log(`Encountered ${mergeCommitShas.length ?? "no"} merge commits`);
 
-  if (
-    mergeCommitShas.length > 0 &&
-    config.commits.merge_commits === "fail"
-  ) {
+  if (mergeCommitShas.length > 0 && config.commits.merge_commits === "fail") {
     throw new MergeCommitsNotAllowedError();
   }
 
-  if (
-    mergeCommitShas.length > 0 &&
-    config.commits.merge_commits === "skip"
-  ) {
+  if (mergeCommitShas.length > 0 && config.commits.merge_commits === "skip") {
     console.log("Skipping merge commits: " + mergeCommitShas);
     commitShasToCherryPick = commitShasToCherryPick.filter(
       (sha) => !mergeCommitShas.includes(sha),

--- a/src/resolve-commits.ts
+++ b/src/resolve-commits.ts
@@ -1,0 +1,127 @@
+import dedent from "dedent";
+
+import type { Config } from "./backport.js";
+import type { GitApi } from "./git.js";
+import { GithubApi, MergeStrategy, PullRequest } from "./github.js";
+
+/**
+ * Thrown when the source PR contains merge commits and `merge_commits` is
+ * configured to `fail`. Carries the user-facing message so the caller can
+ * post it as a comment on the source PR without duplicating wording.
+ */
+export class MergeCommitsNotAllowedError extends Error {
+  constructor() {
+    super(
+      dedent`Backport failed because this pull request contains merge commits. \
+        You can either backport this pull request manually, or configure the action to skip merge commits.`,
+    );
+    this.name = "MergeCommitsNotAllowedError";
+  }
+}
+
+/**
+ * Resolves the list of commit SHAs to cherry-pick for a backport.
+ *
+ * Steps:
+ *   1. Fetches the source PR's commits.
+ *   2. Detects the merge strategy (squash/rebase/merge) and resolves the
+ *      correct SHAs to cherry-pick.
+ *   3. Detects merge commits in the range and either filters them out
+ *      (`merge_commits: skip`) or throws (`merge_commits: fail`).
+ */
+export async function resolveCommitsToCherryPick(
+  git: GitApi,
+  github: GithubApi,
+  config: Pick<Config, "pwd" | "commits">,
+  mainpr: PullRequest,
+  pullNumber: number,
+): Promise<string[]> {
+  console.log(
+    `Fetching all the commits from the pull request: ${mainpr.commits + 1}`,
+  );
+  await git.fetch(
+    `refs/pull/${pullNumber}/head`,
+    config.pwd,
+    mainpr.commits + 1, // +1 in case this concerns a shallowly cloned repo
+  );
+
+  const commitShas = await github.getCommits(mainpr);
+
+  let commitShasToCherryPick: string[];
+
+  if (config.commits.cherry_picking === "auto") {
+    const merge_commit_sha = await github.getMergeCommitSha(mainpr);
+
+    // switch case to check if it is a squash, rebase, or merge commit
+    switch (await github.mergeStrategy(mainpr, merge_commit_sha)) {
+      case MergeStrategy.SQUASHED:
+        // If merged via a squash merge_commit_sha represents the SHA of the squashed commit on
+        // the base branch. We must fetch it and its parent in case of a shallowly cloned repo
+        // To store the fetched commits indefinitely we save them to a remote ref using the sha
+        await git.fetch(
+          `+${merge_commit_sha}:refs/remotes/origin/${merge_commit_sha}`,
+          config.pwd,
+          2, // +1 in case this concerns a shallowly cloned repo
+        );
+        commitShasToCherryPick = [merge_commit_sha!];
+        break;
+      case MergeStrategy.REBASED:
+        // If rebased merge_commit_sha represents the commit that the base branch was updated to
+        // We must fetch it, its parents, and one extra parent in case of a shallowly cloned repo
+        // To store the fetched commits indefinitely we save them to a remote ref using the sha
+        await git.fetch(
+          `+${merge_commit_sha}:refs/remotes/origin/${merge_commit_sha}`,
+          config.pwd,
+          mainpr.commits + 1, // +1 in case this concerns a shallowly cloned repo
+        );
+        const range = `${merge_commit_sha}~${mainpr.commits}..${merge_commit_sha}`;
+        commitShasToCherryPick = await git.findCommitsInRange(range, config.pwd);
+        break;
+      case MergeStrategy.MERGECOMMIT:
+        commitShasToCherryPick = commitShas;
+        break;
+      case MergeStrategy.UNKNOWN:
+      default:
+        console.log(
+          "Could not detect merge strategy. Using commits from the Pull Request.",
+        );
+        commitShasToCherryPick = commitShas;
+        break;
+    }
+  } else {
+    console.log(
+      "Not detecting merge strategy. Using commits from the Pull Request.",
+    );
+    commitShasToCherryPick = commitShas;
+  }
+  console.log(`Found commits to backport: ${commitShasToCherryPick}`);
+
+  console.log("Checking the merged pull request for merge commits");
+  const mergeCommitShas = await git.findMergeCommits(
+    commitShasToCherryPick,
+    config.pwd,
+  );
+  console.log(`Encountered ${mergeCommitShas.length ?? "no"} merge commits`);
+
+  if (
+    mergeCommitShas.length > 0 &&
+    config.commits.merge_commits === "fail"
+  ) {
+    throw new MergeCommitsNotAllowedError();
+  }
+
+  if (
+    mergeCommitShas.length > 0 &&
+    config.commits.merge_commits === "skip"
+  ) {
+    console.log("Skipping merge commits: " + mergeCommitShas);
+    commitShasToCherryPick = commitShasToCherryPick.filter(
+      (sha) => !mergeCommitShas.includes(sha),
+    );
+  }
+  console.log(
+    "Will cherry-pick the following commits: " + commitShasToCherryPick,
+  );
+
+  return commitShasToCherryPick;
+}

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -32,6 +32,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Backport } from "../backport.js";
+import { GitPushError } from "../errors.js";
 import { GitRefNotFoundError } from "../git.js";
 import { MergeStrategy } from "../github.js";
 import { FakeGithub, requestError } from "./helpers/fake-github.js";
@@ -278,7 +279,11 @@ describe("Backport.run() orchestration", () => {
     it("push fails, branch exists: recovers and creates PR", async () => {
       const github = new FakeGithub();
       const git = createMockGit({
-        push: vi.fn().mockResolvedValue(1),
+        push: vi
+          .fn()
+          .mockRejectedValue(
+            new GitPushError("push failed", "branch", "origin", 1),
+          ),
       });
       const config = makeConfig();
       const backport = new Backport(github, config, git);
@@ -290,7 +295,11 @@ describe("Backport.run() orchestration", () => {
     it("push fails, branch doesn't exist: posts failure comment", async () => {
       const github = new FakeGithub();
       const git = createMockGit({
-        push: vi.fn().mockResolvedValue(1),
+        push: vi
+          .fn()
+          .mockRejectedValue(
+            new GitPushError("push failed", "branch", "origin", 1),
+          ),
         fetch: vi
           .fn()
           .mockResolvedValue(undefined)

--- a/src/test/helpers/fake-github.ts
+++ b/src/test/helpers/fake-github.ts
@@ -124,6 +124,14 @@ export class FakeGithub implements GithubApi {
     return this._sourcePr.number;
   }
 
+  getRunId(): string {
+    return "12345";
+  }
+
+  getRunUrl(): string {
+    return "https://github.com/test-owner/test-repo/actions/runs/12345";
+  }
+
   async getPullRequest(_pull_number: number): Promise<PullRequest> {
     return this._sourcePr;
   }

--- a/src/test/helpers/mock-git.ts
+++ b/src/test/helpers/mock-git.ts
@@ -7,7 +7,7 @@ export function createMockGit(overrides?: Partial<GitApi>): GitApi {
     remoteAdd: vi.fn().mockResolvedValue(undefined),
     findCommitsInRange: vi.fn().mockResolvedValue([]),
     findMergeCommits: vi.fn().mockResolvedValue([]),
-    push: vi.fn().mockResolvedValue(0),
+    push: vi.fn().mockResolvedValue(undefined),
     checkout: vi.fn().mockResolvedValue(undefined),
     cherryPick: vi.fn().mockResolvedValue(null),
     ...overrides,


### PR DESCRIPTION
## Why

`Backport.run()` is ~615 lines mixing setup, validation, commit resolution, per-target backporting, PR creation, 8 post-creation side-effects, error handling, and comment formatting. This makes it hard to reason about, hard to extend (e.g. #415), and has led to inconsistent error handling (mixed exceptions and return codes) with ambiguous variable names.

## What

Pure structural refactoring — no user-visible changes. Each commit compiles and passes all existing tests.

1. **Rename variables** — `owner`/`repo`/`target` → `targetOwner`/`targetRepo`/`targetBranch` + `workflowOwner`/`workflowRepo`
2. **Extract `resolveCommitsToCherryPick`** to `src/resolve-commits.ts`
3. **Extract `postCreatePR`** to `src/pr-post-create.ts`
4. **Introduce error type hierarchy** in `src/errors.ts` — `BackportError`, `CheckoutError`, `CherryPickError`, `GitPushError`, `CreatePRError`. `git.ts` throws `GitPushError` consistently; `push()` returns `Promise<void>` instead of an exit code.
5. **Extract `backportToTarget` method** with `BackportContext` type
6. **Return `TargetResult`** from `backportToTarget` instead of `boolean` — comment posting moves to `run()`

`run()` is now a clearer orchestration method. Commit resolution and post-creation effects each live in their own module.

Also adds `CLAUDE.md` with project conventions for AI tooling.

## Test plan

- [x] All 97 existing tests pass after every commit
- [x] No behavioral change — same comments, same outputs, same error handling
- [ ] Run E2E tests in `korthout/backport-action-test` before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)