### PR TITLE
Add summary comment style

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,14 @@ Specifically, those reachable from the pull request's head and not reachable fro
 
 By default, the action cherry-picks the commits based on the method used to merge the pull request.
 
+### `comment_style`
+
+Default: `legacy`
+
+Controls the style of comments posted by the action.
+When set to `legacy`, the action posts individual comments per target branch.
+When set to `summary`, the action posts a single summary comment per workflow run with actionable details.
+
 ### `copy_all_reviewers`
 
 Default: `false` (disabled)

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,12 @@ inputs:
 
       By default, the action cherry-picks the commits based on the method used to merge the pull request.
     default: auto
+  comment_style:
+    description: >
+      Controls the style of comments posted by the action.
+      When set to `legacy`, the action posts individual comments per target branch.
+      When set to `summary`, the action posts a single summary comment per workflow run with actionable details.
+    default: legacy
   copy_all_reviewers:
     description: >
       Controls whether to copy all reviewers from the original pull request to the backport pull request.

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -107,6 +107,7 @@ export type Config = {
   add_team_reviewers: string[];
   auto_merge_enabled: boolean;
   auto_merge_method: "merge" | "squash" | "rebase";
+  comment_style: "legacy" | "summary";
   experimental: Experimental;
 };
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -9,6 +9,11 @@ import {
 import { GithubApi } from "./github.js";
 import { GitApi, GitRefNotFoundError } from "./git.js";
 import {
+  CommentContext,
+  formatInitialComment,
+  formatRunComment,
+} from "./comments.js";
+import {
   CheckoutError,
   CherryPickError,
   CreatePRError,
@@ -48,7 +53,6 @@ type BackportContext = {
   labelsToCopy: string[];
   mainpr: PullRequest;
 };
-
 
 export type Config = {
   pwd: string;
@@ -156,14 +160,51 @@ export class Backport {
           : this.config.source_pr_number;
       const mainpr = await this.github.getPullRequest(pull_number);
 
+      const isSummary = this.config.comment_style === "summary";
+      const commentCtx: CommentContext = {
+        runId: this.github.getRunId(),
+        runUrl: this.github.getRunUrl(),
+      };
+
+      // For the summary style, create the placeholder comment as early as
+      // possible (before validating the PR) so we can update it with errors
+      // even if validation fails. Comment creation is best-effort: on
+      // failure we log and continue without commenting.
+      let summaryCommentId: number | undefined;
+      if (isSummary) {
+        try {
+          summaryCommentId = await this.github.createComment({
+            owner: workflowOwner,
+            repo: workflowRepo,
+            issue_number: pull_number,
+            body: formatInitialComment(commentCtx),
+          });
+        } catch (error) {
+          console.error("Failed to create summary comment:", error);
+        }
+      }
+
+      const updateSummary = async (body: string) => {
+        if (summaryCommentId === undefined) return;
+        try {
+          await this.github.updateComment(summaryCommentId, body);
+        } catch (error) {
+          console.error("Failed to update summary comment:", error);
+        }
+      };
+
       if (!(await this.github.isMerged(mainpr))) {
         const message = "Only merged pull requests can be backported.";
-        this.github.createComment({
-          owner: workflowOwner,
-          repo: workflowRepo,
-          issue_number: pull_number,
-          body: message,
-        });
+        if (isSummary) {
+          await updateSummary(formatRunComment([], [], commentCtx, message));
+        } else {
+          this.github.createComment({
+            owner: workflowOwner,
+            repo: workflowRepo,
+            issue_number: pull_number,
+            body: message,
+          });
+        }
         return;
       }
 
@@ -172,7 +213,17 @@ export class Backport {
         console.log(
           `Nothing to backport: no 'target_branches' specified and none of the labels match the backport pattern '${this.config.source_labels_pattern?.source}'`,
         );
+        if (isSummary) {
+          // No targets to backport — update to the "backported" wording
+          // with no table. This is not a failure.
+          await updateSummary(formatRunComment([], [], commentCtx));
+        }
         return; // nothing left to do here
+      }
+
+      if (isSummary) {
+        // Targets known but not yet processed — show all-pending table
+        await updateSummary(formatRunComment([], target_branches, commentCtx));
       }
 
       let commitShasToCherryPick: string[];
@@ -187,13 +238,24 @@ export class Backport {
       } catch (error) {
         if (error instanceof MergeCommitsNotAllowedError) {
           console.error(error.message);
-          this.github.createComment({
-            owner: workflowOwner,
-            repo: workflowRepo,
-            issue_number: pull_number,
-            body: error.message,
-          });
+          if (isSummary) {
+            await updateSummary(
+              formatRunComment([], target_branches, commentCtx, error.message),
+            );
+          } else {
+            this.github.createComment({
+              owner: workflowOwner,
+              repo: workflowRepo,
+              issue_number: pull_number,
+              body: error.message,
+            });
+          }
           return;
+        }
+        if (isSummary && error instanceof Error) {
+          await updateSummary(
+            formatRunComment([], target_branches, commentCtx, error.message),
+          );
         }
         throw error;
       }
@@ -229,8 +291,8 @@ export class Backport {
         targetOwner,
         targetRepo,
         pullNumber: pull_number,
-        runId: this.github.getRunId(),
-        runUrl: this.github.getRunUrl(),
+        runId: commentCtx.runId,
+        runUrl: commentCtx.runUrl,
         remote: this.getRemote(),
         commitShasToCherryPick,
         labelsToCopy,
@@ -239,9 +301,20 @@ export class Backport {
 
       const successByTarget = new Map<string, boolean>();
       const createdPullRequestNumbers = new Array<number>();
-      for (const targetBranch of target_branches) {
+      const results: TargetResult[] = [];
+      for (let i = 0; i < target_branches.length; i++) {
+        const targetBranch = target_branches[i];
         const result = await this.backportToTarget(targetBranch, context);
-        await this.handleTargetResultLegacy(result, context);
+        results.push(result);
+
+        if (isSummary) {
+          const remainingTargets = target_branches.slice(i + 1);
+          await updateSummary(
+            formatRunComment(results, remainingTargets, commentCtx),
+          );
+        } else {
+          await this.handleTargetResultLegacy(result, context);
+        }
 
         if (result.status === "skipped") continue;
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -9,11 +9,11 @@ import {
 import { GithubApi } from "./github.js";
 import { GitApi, GitRefNotFoundError } from "./git.js";
 import {
-  BackportError,
   CheckoutError,
   CherryPickError,
   CreatePRError,
   GitPushError,
+  TargetResult,
 } from "./errors.js";
 import { postCreatePR } from "./pr-post-create.js";
 import {
@@ -49,37 +49,6 @@ type BackportContext = {
   mainpr: PullRequest;
 };
 
-/**
- * Outcome of a single per-target backport attempt.
- *
- * `backportToTarget` returns one of these so that comment posting and
- * bookkeeping can be done in `run()`, where they can also be replaced by
- * the progressive summary comment in Phase 8c.
- *
- * Phase 8a moves this type to `errors.ts` so `comments.ts` can import it
- * without depending on `backport.ts`.
- */
-export type TargetResult =
-  | {
-      status: "success";
-      targetBranch: string;
-      newPrNumber: number;
-      branchname: string;
-    }
-  | {
-      status: "success_with_conflicts";
-      targetBranch: string;
-      newPrNumber: number;
-      branchname: string;
-      uncommittedShas: string[];
-    }
-  | { status: "skipped"; targetBranch: string; reason: string }
-  | {
-      status: "failed";
-      targetBranch: string;
-      error: BackportError | Error;
-      branchname?: string;
-    };
 
 export type Config = {
   pwd: string;

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -20,6 +20,12 @@ import {
   GitPushError,
   TargetResult,
 } from "./errors.js";
+import {
+  composeFailureMessage,
+  composeMessageForSuccess,
+  composeMessageForSuccessWithConflicts,
+  composeMessageToResolveCommittedConflicts,
+} from "./legacy-comments.js";
 import { postCreatePR } from "./pr-post-create.js";
 import {
   MergeCommitsNotAllowedError,
@@ -544,7 +550,7 @@ export class Backport {
     if (result.status === "skipped") return;
 
     if (result.status === "failed") {
-      const message = this.composeFailureMessage(result, context);
+      const message = composeFailureMessage(result);
       console.error(message);
       await this.github.createComment({
         owner: workflowOwner,
@@ -562,7 +568,7 @@ export class Backport {
 
     const successMessage =
       result.status === "success_with_conflicts"
-        ? this.composeMessageForSuccessWithConflicts(
+        ? composeMessageForSuccessWithConflicts(
             newPrNumber,
             targetBranch,
             downstream,
@@ -570,7 +576,7 @@ export class Backport {
             result.uncommittedShas,
             this.config.experimental.conflict_resolution,
           )
-        : this.composeMessageForSuccess(newPrNumber, targetBranch, downstream);
+        : composeMessageForSuccess(newPrNumber, targetBranch, downstream);
 
     await this.github.createComment({
       owner: workflowOwner,
@@ -580,7 +586,7 @@ export class Backport {
     });
 
     if (result.status === "success_with_conflicts") {
-      const conflictMessage = this.composeMessageToResolveCommittedConflicts(
+      const conflictMessage = composeMessageToResolveCommittedConflicts(
         targetBranch,
         branchname,
         result.uncommittedShas,
@@ -595,40 +601,6 @@ export class Backport {
     }
   }
 
-  private composeFailureMessage(
-    result: Extract<TargetResult, { status: "failed" }>,
-    context: BackportContext,
-  ): string {
-    const { targetBranch, error } = result;
-    if (error instanceof GitRefNotFoundError) {
-      return this.composeMessageForFetchTargetFailure(error.ref);
-    }
-    if (error instanceof CheckoutError) {
-      return this.composeMessageForCheckoutFailure(
-        targetBranch,
-        error.branch,
-        error.commits,
-      );
-    }
-    if (error instanceof CherryPickError) {
-      return this.composeMessageForCherryPickFailure(
-        targetBranch,
-        error.branch,
-        error.commits,
-      );
-    }
-    if (error instanceof GitPushError) {
-      return this.composeMessageForGitPushFailure(targetBranch, error.exitCode);
-    }
-    if (error instanceof CreatePRError) {
-      return dedent`Backport branch created but failed to create PR.
-                    Request to create PR rejected with status ${error.status}.
-
-                    (see action log for full response)`;
-    }
-    return error.message;
-  }
-
   private composePRContent(target: string, main: PullRequest): PRContent {
     const title = utils.replacePlaceholders(
       this.config.pull.title,
@@ -641,135 +613,6 @@ export class Backport {
       target,
     );
     return { title, body };
-  }
-
-  private composeMessageForFetchTargetFailure(target: string) {
-    return dedent`Backport failed for \`${target}\`: couldn't find remote ref \`${target}\`.
-                  Please ensure that this Github repo has a branch named \`${target}\`.`;
-  }
-
-  private composeMessageForCheckoutFailure(
-    target: string,
-    branchname: string,
-    commitShasToCherryPick: string[],
-  ): string {
-    const reason = "because it was unable to create a new branch";
-    const suggestion = this.composeSuggestion(
-      target,
-      branchname,
-      commitShasToCherryPick,
-      false,
-    );
-    return dedent`Backport failed for \`${target}\`, ${reason}.
-
-                  Please cherry-pick the changes locally.
-                  ${suggestion}`;
-  }
-
-  private composeMessageForCherryPickFailure(
-    target: string,
-    branchname: string,
-    commitShasToCherryPick: string[],
-  ): string {
-    const reason = "because it was unable to cherry-pick the commit(s)";
-
-    const suggestion = this.composeSuggestion(
-      target,
-      branchname,
-      commitShasToCherryPick,
-      false,
-      "fail",
-    );
-
-    return dedent`Backport failed for \`${target}\`, ${reason}.
-
-                  Please cherry-pick the changes locally and resolve any conflicts.
-                  ${suggestion}`;
-  }
-
-  private composeMessageToResolveCommittedConflicts(
-    target: string,
-    branchname: string,
-    commitShasToCherryPick: string[],
-    confictResolution: string,
-  ): string {
-    const suggestion = this.composeSuggestion(
-      target,
-      branchname,
-      commitShasToCherryPick,
-      true,
-      confictResolution,
-    );
-
-    return dedent`Please cherry-pick the changes locally and resolve any conflicts.
-                  ${suggestion}`;
-  }
-
-  private composeSuggestion(
-    target: string,
-    branchname: string,
-    commitShasToCherryPick: string[],
-    branchExist: boolean,
-    confictResolution: string = "fail",
-  ) {
-    if (branchExist) {
-      if (confictResolution === "draft_commit_conflicts") {
-        return dedent`\`\`\`bash
-        git fetch origin ${branchname}
-        git worktree add --checkout .worktree/${branchname} ${branchname}
-        cd .worktree/${branchname}
-        git reset --hard HEAD^
-        git cherry-pick -x ${commitShasToCherryPick.join(" ")}
-        \`\`\``;
-      } else {
-        return "";
-      }
-    } else {
-      return dedent`\`\`\`bash
-      git fetch origin ${target}
-      git worktree add -d .worktree/${branchname} origin/${target}
-      cd .worktree/${branchname}
-      git switch --create ${branchname}
-      git cherry-pick -x ${commitShasToCherryPick.join(" ")}
-      \`\`\``;
-    }
-  }
-
-  private composeMessageForGitPushFailure(
-    target: string,
-    exitcode: number,
-  ): string {
-    //TODO better error messages depending on exit code
-    return dedent`Git push to origin failed for ${target} with exitcode ${exitcode}`;
-  }
-
-  private composeMessageForSuccess(
-    pr_number: number,
-    target: string,
-    downstream: string,
-  ) {
-    return dedent`Successfully created backport PR for \`${target}\`:
-                  - ${downstream}#${pr_number}`;
-  }
-
-  private composeMessageForSuccessWithConflicts(
-    pr_number: number,
-    target: string,
-    downstream: string,
-    branchname: string,
-    commitShasToCherryPick: string[],
-    conflictResolution: string,
-  ): string {
-    const suggestionToResolve = this.composeMessageToResolveCommittedConflicts(
-      target,
-      branchname,
-      commitShasToCherryPick,
-      conflictResolution,
-    );
-    return dedent`Created backport PR for \`${target}\`:
-                  - ${downstream}#${pr_number} with remaining conflicts!
-
-                  ${suggestionToResolve}`;
   }
 
   private createOutput(

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,0 +1,188 @@
+import dedent from "dedent";
+
+import {
+  CheckoutError,
+  CherryPickError,
+  CreatePRError,
+  GitPushError,
+  TargetResult,
+} from "./errors.js";
+import { GitRefNotFoundError } from "./git.js";
+
+/**
+ * Per-run context required to render the summary comment.
+ *
+ * Kept intentionally minimal: every other piece of information the
+ * formatters need is on the {@link TargetResult} or its embedded error.
+ */
+export type CommentContext = {
+  runId: string;
+  runUrl: string;
+};
+
+const ACTION_LINK = "[Backport-action](https://github.com/korthout/backport-action)";
+
+/**
+ * Renders the full progressive summary comment.
+ *
+ * @param results   per-target outcomes that have already been processed
+ * @param pendingTargets target branches that have not been processed yet
+ * @param context   run-id and run-url for the workflow run link
+ * @param error     pre-loop failure message (e.g. PR not merged); when set,
+ *                  `results` should be empty
+ */
+export function formatRunComment(
+  results: TargetResult[],
+  pendingTargets: string[],
+  context: CommentContext,
+  error?: string,
+): string {
+  const intro = formatIntroduction(results, pendingTargets, context, error);
+  const errorBlock = error ? `\n\n${error}` : "";
+  const table = formatTable(results, pendingTargets);
+  const detailsBlocks = results
+    .filter((r): r is Extract<TargetResult, { status: "failed" }> =>
+      r.status === "failed",
+    )
+    .map((r) => formatSingleTargetComment(r, context))
+    .join("\n\n");
+
+  let out = intro;
+  if (errorBlock) out += errorBlock;
+  if (table) out += `\n\n${table}`;
+  if (detailsBlocks) out += `\n\n${detailsBlocks}`;
+  return out;
+}
+
+function formatIntroduction(
+  results: TargetResult[],
+  pendingTargets: string[],
+  context: CommentContext,
+  error?: string,
+): string {
+  const runLink = `[workflow run ${context.runId}](${context.runUrl})`;
+  if (error) {
+    return `${ACTION_LINK} failed to backport this pull request in ${runLink}.`;
+  }
+  if (pendingTargets.length > 0 || results.length === 0) {
+    return `${ACTION_LINK} is backporting this pull request in ${runLink}.`;
+  }
+  return `${ACTION_LINK} backported this pull request in ${runLink}.`;
+}
+
+function formatTable(
+  results: TargetResult[],
+  pendingTargets: string[],
+): string {
+  if (results.length === 0 && pendingTargets.length === 0) return "";
+
+  const rows: string[] = [];
+  for (const result of results) {
+    rows.push(`| \`${result.targetBranch}\` | ${formatStatusCell(result)} |`);
+  }
+  for (const target of pendingTargets) {
+    rows.push(`| \`${target}\` | :hourglass: Pending |`);
+  }
+
+  return ["| Target | Status |", "|--------|--------|", ...rows].join("\n");
+}
+
+function formatStatusCell(result: TargetResult): string {
+  switch (result.status) {
+    case "success":
+      return `:white_check_mark: Created #${result.newPrNumber}`;
+    case "success_with_conflicts":
+      return `:warning: Drafted with conflicts #${result.newPrNumber}`;
+    case "skipped":
+      return `:heavy_minus_sign: Skipped (${result.reason})`;
+    case "failed":
+      return ":x: Failed";
+  }
+}
+
+/**
+ * Renders the collapsible `<details>` block for a single failed target.
+ *
+ * Private building block of {@link formatRunComment}. Exported only for
+ * unit testing — callers should use `formatRunComment` to render full
+ * progressive comments.
+ */
+export function formatSingleTargetComment(
+  result: Extract<TargetResult, { status: "failed" }>,
+  _context: CommentContext,
+): string {
+  const { targetBranch, error } = result;
+
+  if (error instanceof GitRefNotFoundError) {
+    return wrapDetails(
+      `:x: ${targetBranch} — target branch not found`,
+      dedent`Tried to fetch \`${error.ref}\`, but the ref was not found on the remote.
+
+             Please ensure that this Github repo has a branch named \`${error.ref}\`.`,
+    );
+  }
+
+  if (error instanceof CheckoutError) {
+    return wrapDetails(
+      `:x: ${targetBranch} — unable to create backport branch`,
+      dedent`Tried to create a backport branch \`${error.branch}\` from \`${targetBranch}\`, but the checkout failed.
+
+             Please cherry-pick the changes locally:
+             \`\`\`bash
+             git fetch origin ${targetBranch}
+             git worktree add -d .worktree/${error.branch} origin/${targetBranch}
+             cd .worktree/${error.branch}
+             git switch --create ${error.branch}
+             git cherry-pick -x ${error.commits.join(" ")}
+             \`\`\``,
+    );
+  }
+
+  if (error instanceof CherryPickError) {
+    return wrapDetails(
+      `:x: ${targetBranch} — unable to cherry-pick`,
+      dedent`Tried to cherry-pick commits onto \`${targetBranch}\`, but the cherry-pick failed.
+
+             Please cherry-pick the changes locally and resolve any conflicts:
+             \`\`\`bash
+             git fetch origin ${targetBranch}
+             git worktree add -d .worktree/${error.branch} origin/${targetBranch}
+             cd .worktree/${error.branch}
+             git switch --create ${error.branch}
+             git cherry-pick -x ${error.commits.join(" ")}
+             \`\`\``,
+    );
+  }
+
+  if (error instanceof GitPushError) {
+    return wrapDetails(
+      `:x: ${targetBranch} — push failed`,
+      dedent`Tried to push backport branch \`${error.branch}\` to \`${error.remote}\`, but the push failed (exit code ${error.exitCode}).
+
+             This usually means the token lacks permission to push to this repository. Consider using a Personal Access Token (PAT) with \`repo\` scope as \`github_token\`.`,
+    );
+  }
+
+  if (error instanceof CreatePRError) {
+    const responseLine = error.responseMessage
+      ? `\n\nResponse: ${error.responseMessage}`
+      : "";
+    return wrapDetails(
+      `:x: ${targetBranch} — failed to create pull request`,
+      dedent`Backport branch was created, but creating the pull request failed with status ${error.status}.${responseLine}
+
+             See the workflow run logs for the full response.`,
+    );
+  }
+
+  return wrapDetails(
+    `:x: ${targetBranch} — unexpected failure`,
+    dedent`An unexpected error occurred while backporting to \`${targetBranch}\`.
+
+           Please check the workflow run logs for the full error and stack trace, and consider reporting this as a bug at https://github.com/korthout/backport-action/issues.`,
+  );
+}
+
+function wrapDetails(summary: string, body: string): string {
+  return `<details><summary>${summary}</summary>\n\n${body}\n\n</details>`;
+}

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -57,7 +57,7 @@ export function formatRunComment(
 }
 
 function formatIntroduction(
-  _results: TargetResult[],
+  results: TargetResult[],
   pendingTargets: string[],
   context: CommentContext,
   error?: string,
@@ -68,6 +68,13 @@ function formatIntroduction(
   }
   if (pendingTargets.length > 0) {
     return `${ACTION_LINK} is backporting this pull request in ${runLink}.`;
+  }
+  const failedCount = results.filter((r) => r.status === "failed").length;
+  if (failedCount > 0 && failedCount === results.length) {
+    return `${ACTION_LINK} failed to backport this pull request in ${runLink}.`;
+  }
+  if (failedCount > 0) {
+    return `${ACTION_LINK} completed backporting this pull request with failures in ${runLink}.`;
   }
   return `${ACTION_LINK} backported this pull request in ${runLink}.`;
 }

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -137,7 +137,7 @@ export function formatSingleTargetComment(
       `:x: ${targetBranch} — target branch not found`,
       dedent`Tried to fetch \`${error.ref}\`, but the ref was not found on the remote.
 
-             Please ensure that this Github repo has a branch named \`${error.ref}\`.`,
+             Please ensure that this GitHub repo has a branch named \`${error.ref}\`.`,
     );
   }
 

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -20,7 +20,8 @@ export type CommentContext = {
   runUrl: string;
 };
 
-const ACTION_LINK = "[Backport-action](https://github.com/korthout/backport-action)";
+const ACTION_LINK =
+  "[Backport-action](https://github.com/korthout/backport-action)";
 
 /**
  * Renders the full progressive summary comment.
@@ -41,8 +42,9 @@ export function formatRunComment(
   const errorBlock = error ? `\n\n${error}` : "";
   const table = formatTable(results, pendingTargets);
   const detailsBlocks = results
-    .filter((r): r is Extract<TargetResult, { status: "failed" }> =>
-      r.status === "failed",
+    .filter(
+      (r): r is Extract<TargetResult, { status: "failed" }> =>
+        r.status === "failed",
     )
     .map((r) => formatSingleTargetComment(r, context))
     .join("\n\n");
@@ -55,7 +57,7 @@ export function formatRunComment(
 }
 
 function formatIntroduction(
-  results: TargetResult[],
+  _results: TargetResult[],
   pendingTargets: string[],
   context: CommentContext,
   error?: string,
@@ -64,10 +66,20 @@ function formatIntroduction(
   if (error) {
     return `${ACTION_LINK} failed to backport this pull request in ${runLink}.`;
   }
-  if (pendingTargets.length > 0 || results.length === 0) {
+  if (pendingTargets.length > 0) {
     return `${ACTION_LINK} is backporting this pull request in ${runLink}.`;
   }
   return `${ACTION_LINK} backported this pull request in ${runLink}.`;
+}
+
+/**
+ * Initial placeholder body posted right after the action starts, before
+ * targets are known. Replaced by `formatRunComment` updates on subsequent
+ * events.
+ */
+export function formatInitialComment(context: CommentContext): string {
+  const runLink = `[workflow run ${context.runId}](${context.runUrl})`;
+  return `${ACTION_LINK} is backporting this pull request in ${runLink}.`;
 }
 
 function formatTable(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -66,3 +66,32 @@ export class CreatePRError extends BackportError {
     this.responseMessage = responseMessage;
   }
 }
+
+/**
+ * Outcome of a single per-target backport attempt.
+ *
+ * Lives in errors.ts so both backport.ts (which produces the result) and
+ * comments.ts (which renders it) can import it without depending on each
+ * other.
+ */
+export type TargetResult =
+  | {
+      status: "success";
+      targetBranch: string;
+      newPrNumber: number;
+      branchname: string;
+    }
+  | {
+      status: "success_with_conflicts";
+      targetBranch: string;
+      newPrNumber: number;
+      branchname: string;
+      uncommittedShas: string[];
+    }
+  | { status: "skipped"; targetBranch: string; reason: string }
+  | {
+      status: "failed";
+      targetBranch: string;
+      error: BackportError | Error;
+      branchname?: string;
+    };

--- a/src/github.ts
+++ b/src/github.ts
@@ -16,7 +16,8 @@ export interface GithubApi {
   getPullNumber(): number;
   getRunId(): string;
   getRunUrl(): string;
-  createComment(comment: Comment): Promise<{}>;
+  createComment(comment: Comment): Promise<number>;
+  updateComment(comment_id: number, body: string): Promise<{}>;
   getPullRequest(pull_number: number): Promise<PullRequest>;
   isMerged(pull: PullRequest): Promise<boolean>;
   getCommits(pull: PullRequest): Promise<string[]>;
@@ -88,9 +89,21 @@ export class Github implements GithubApi {
     return `${serverUrl}/${repository}/actions/runs/${runId}`;
   }
 
-  public async createComment(comment: Comment) {
+  public async createComment(comment: Comment): Promise<number> {
     console.log(`Create comment: ${comment.body}`);
-    return this.#octokit.rest.issues.createComment(comment);
+    const response = await this.#octokit.rest.issues.createComment(comment);
+    return response.data.id;
+  }
+
+  public async updateComment(comment_id: number, body: string) {
+    console.log(`Update comment ${comment_id}: ${body}`);
+    const { owner, repo } = this.getRepo();
+    return this.#octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id,
+      body,
+    });
   }
 
   public async getPullRequest(pull_number: number) {

--- a/src/legacy-comments.ts
+++ b/src/legacy-comments.ts
@@ -75,14 +75,14 @@ export function composeMessageToResolveCommittedConflicts(
   target: string,
   branchname: string,
   commitShasToCherryPick: string[],
-  confictResolution: string,
+  conflictResolution: string,
 ): string {
   const suggestion = composeSuggestion(
     target,
     branchname,
     commitShasToCherryPick,
     true,
-    confictResolution,
+    conflictResolution,
   );
 
   return dedent`Please cherry-pick the changes locally and resolve any conflicts.
@@ -91,7 +91,7 @@ export function composeMessageToResolveCommittedConflicts(
 
 function composeMessageForFetchTargetFailure(target: string): string {
   return dedent`Backport failed for \`${target}\`: couldn't find remote ref \`${target}\`.
-                Please ensure that this Github repo has a branch named \`${target}\`.`;
+                Please ensure that this GitHub repo has a branch named \`${target}\`.`;
 }
 
 function composeMessageForCheckoutFailure(
@@ -146,10 +146,10 @@ function composeSuggestion(
   branchname: string,
   commitShasToCherryPick: string[],
   branchExist: boolean,
-  confictResolution: string = "fail",
+  conflictResolution: string = "fail",
 ) {
   if (branchExist) {
-    if (confictResolution === "draft_commit_conflicts") {
+    if (conflictResolution === "draft_commit_conflicts") {
       return dedent`\`\`\`bash
       git fetch origin ${branchname}
       git worktree add --checkout .worktree/${branchname} ${branchname}

--- a/src/legacy-comments.ts
+++ b/src/legacy-comments.ts
@@ -1,0 +1,172 @@
+import dedent from "dedent";
+
+import {
+  CheckoutError,
+  CherryPickError,
+  CreatePRError,
+  GitPushError,
+  TargetResult,
+} from "./errors.js";
+import { GitRefNotFoundError } from "./git.js";
+
+export function composeFailureMessage(
+  result: Extract<TargetResult, { status: "failed" }>,
+): string {
+  const { targetBranch, error } = result;
+  if (error instanceof GitRefNotFoundError) {
+    return composeMessageForFetchTargetFailure(error.ref);
+  }
+  if (error instanceof CheckoutError) {
+    return composeMessageForCheckoutFailure(
+      targetBranch,
+      error.branch,
+      error.commits,
+    );
+  }
+  if (error instanceof CherryPickError) {
+    return composeMessageForCherryPickFailure(
+      targetBranch,
+      error.branch,
+      error.commits,
+    );
+  }
+  if (error instanceof GitPushError) {
+    return composeMessageForGitPushFailure(targetBranch, error.exitCode);
+  }
+  if (error instanceof CreatePRError) {
+    return dedent`Backport branch created but failed to create PR.
+                  Request to create PR rejected with status ${error.status}.
+
+                  (see action log for full response)`;
+  }
+  return error.message;
+}
+
+export function composeMessageForSuccess(
+  pr_number: number,
+  target: string,
+  downstream: string,
+): string {
+  return dedent`Successfully created backport PR for \`${target}\`:
+                - ${downstream}#${pr_number}`;
+}
+
+export function composeMessageForSuccessWithConflicts(
+  pr_number: number,
+  target: string,
+  downstream: string,
+  branchname: string,
+  commitShasToCherryPick: string[],
+  conflictResolution: string,
+): string {
+  const suggestionToResolve = composeMessageToResolveCommittedConflicts(
+    target,
+    branchname,
+    commitShasToCherryPick,
+    conflictResolution,
+  );
+  return dedent`Created backport PR for \`${target}\`:
+                - ${downstream}#${pr_number} with remaining conflicts!
+
+                ${suggestionToResolve}`;
+}
+
+export function composeMessageToResolveCommittedConflicts(
+  target: string,
+  branchname: string,
+  commitShasToCherryPick: string[],
+  confictResolution: string,
+): string {
+  const suggestion = composeSuggestion(
+    target,
+    branchname,
+    commitShasToCherryPick,
+    true,
+    confictResolution,
+  );
+
+  return dedent`Please cherry-pick the changes locally and resolve any conflicts.
+                ${suggestion}`;
+}
+
+function composeMessageForFetchTargetFailure(target: string): string {
+  return dedent`Backport failed for \`${target}\`: couldn't find remote ref \`${target}\`.
+                Please ensure that this Github repo has a branch named \`${target}\`.`;
+}
+
+function composeMessageForCheckoutFailure(
+  target: string,
+  branchname: string,
+  commitShasToCherryPick: string[],
+): string {
+  const reason = "because it was unable to create a new branch";
+  const suggestion = composeSuggestion(
+    target,
+    branchname,
+    commitShasToCherryPick,
+    false,
+  );
+  return dedent`Backport failed for \`${target}\`, ${reason}.
+
+                Please cherry-pick the changes locally.
+                ${suggestion}`;
+}
+
+function composeMessageForCherryPickFailure(
+  target: string,
+  branchname: string,
+  commitShasToCherryPick: string[],
+): string {
+  const reason = "because it was unable to cherry-pick the commit(s)";
+
+  const suggestion = composeSuggestion(
+    target,
+    branchname,
+    commitShasToCherryPick,
+    false,
+    "fail",
+  );
+
+  return dedent`Backport failed for \`${target}\`, ${reason}.
+
+                Please cherry-pick the changes locally and resolve any conflicts.
+                ${suggestion}`;
+}
+
+function composeMessageForGitPushFailure(
+  target: string,
+  exitcode: number,
+): string {
+  //TODO better error messages depending on exit code
+  return dedent`Git push to origin failed for ${target} with exitcode ${exitcode}`;
+}
+
+function composeSuggestion(
+  target: string,
+  branchname: string,
+  commitShasToCherryPick: string[],
+  branchExist: boolean,
+  confictResolution: string = "fail",
+) {
+  if (branchExist) {
+    if (confictResolution === "draft_commit_conflicts") {
+      return dedent`\`\`\`bash
+      git fetch origin ${branchname}
+      git worktree add --checkout .worktree/${branchname} ${branchname}
+      cd .worktree/${branchname}
+      git reset --hard HEAD^
+      git cherry-pick -x ${commitShasToCherryPick.join(" ")}
+      \`\`\``;
+    } else {
+      return "";
+    }
+  } else {
+    return dedent`\`\`\`bash
+    git fetch origin ${target}
+    git worktree add -d .worktree/${branchname} origin/${target}
+    cd .worktree/${branchname}
+    git switch --create ${branchname}
+    git cherry-pick -x ${commitShasToCherryPick.join(" ")}
+    \`\`\``;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ async function run(): Promise<void> {
   const add_team_reviewers = core.getInput("add_team_reviewers");
   const auto_merge_enabled = core.getInput("auto_merge_enabled");
   const auto_merge_method = core.getInput("auto_merge_method");
+  const comment_style = core.getInput("comment_style");
   const experimental = JSON.parse(core.getInput("experimental"));
   const source_pr_number = core.getInput("source_pr_number");
 
@@ -61,6 +62,13 @@ async function run(): Promise<void> {
     auto_merge_method !== "rebase"
   ) {
     const message = `Expected input 'auto_merge_method' to be either 'merge', 'squash', or 'rebase', but was '${auto_merge_method}'`;
+    console.error(message);
+    core.setFailed(message);
+    return;
+  }
+
+  if (comment_style !== "legacy" && comment_style !== "summary") {
+    const message = `Expected input 'comment_style' to be either 'legacy' or 'summary', but was '${comment_style}'`;
     console.error(message);
     core.setFailed(message);
     return;
@@ -135,6 +143,7 @@ async function run(): Promise<void> {
             .filter(Boolean),
     auto_merge_enabled: auto_merge_enabled === "true",
     auto_merge_method: auto_merge_method as "merge" | "squash" | "rebase",
+    comment_style: comment_style as "legacy" | "summary",
     experimental: { ...experimentalDefaults, ...experimental },
     source_pr_number:
       source_pr_number === "" ? undefined : parseInt(source_pr_number),

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -715,19 +715,22 @@ describe("Backport.run() orchestration", () => {
       const backport = new Backport(github, config, git);
       await backport.run();
 
-      // Find the targets-known update (all pending, no completed rows)
+      const countMatches = (body: string, marker: string) =>
+        (body.match(new RegExp(marker, "g")) ?? []).length;
+
+      // Targets-known update: both rows pending, no completed rows
       const allPending = github.updatedComments.find(
         (u) =>
-          u.body.includes(":hourglass:") &&
+          countMatches(u.body, ":hourglass:") === 2 &&
           !u.body.includes(":white_check_mark:"),
       );
       expect(allPending).toBeDefined();
 
-      // Find partial update (one completed, one pending)
+      // Partial update: exactly one completed, exactly one pending
       const partial = github.updatedComments.find(
         (u) =>
-          u.body.includes(":white_check_mark:") &&
-          u.body.includes(":hourglass:"),
+          countMatches(u.body, ":white_check_mark:") === 1 &&
+          countMatches(u.body, ":hourglass:") === 1,
       );
       expect(partial).toBeDefined();
 

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -697,6 +697,13 @@ describe("Backport.run() orchestration", () => {
 
       // Initial create + targets-known update + 2 per-target updates = 3 updates
       expect(github.updatedComments.length).toBeGreaterThanOrEqual(3);
+
+      // Every update targets the comment that was created
+      const id = github.comments[0].id;
+      expect(github.updatedComments.every((u) => u.comment_id === id)).toBe(
+        true,
+      );
+
       const finalBody =
         github.updatedComments[github.updatedComments.length - 1].body;
       expect(finalBody).toContain("backported");

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -650,7 +650,7 @@ describe("Backport.run() orchestration", () => {
   });
 
   describe("comment_style: legacy (default)", () => {
-    it("posts per-target comments and never updates", async () => {
+    it("single target: posts one comment and never updates", async () => {
       const github = new FakeGithub();
       const git = createMockGit();
       const config = makeConfig();
@@ -659,6 +659,23 @@ describe("Backport.run() orchestration", () => {
 
       expect(github.comments).toHaveLength(1);
       expect(github.comments[0].body).toContain("Successfully created");
+      expect(github.updatedComments).toHaveLength(0);
+    });
+
+    it("multiple targets: posts one comment per target and never updates", async () => {
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport main" }, { name: "backport release" }],
+        },
+      });
+      const git = createMockGit();
+      const config = makeConfig();
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.comments).toHaveLength(2);
+      expect(github.comments[0].body).toContain("Successfully created");
+      expect(github.comments[1].body).toContain("Successfully created");
       expect(github.updatedComments).toHaveLength(0);
     });
   });

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -648,4 +648,178 @@ describe("Backport.run() orchestration", () => {
       );
     });
   });
+
+  describe("comment_style: legacy (default)", () => {
+    it("posts per-target comments and never updates", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit();
+      const config = makeConfig();
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.comments).toHaveLength(1);
+      expect(github.comments[0].body).toContain("Successfully created");
+      expect(github.updatedComments).toHaveLength(0);
+    });
+  });
+
+  describe("comment_style: summary", () => {
+    it("creates a single comment up front and updates it after each target", async () => {
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport main" }, { name: "backport release" }],
+        },
+      });
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.comments).toHaveLength(1);
+      expect(github.comments[0].body).toContain("is backporting");
+
+      // Initial create + targets-known update + 2 per-target updates = 3 updates
+      expect(github.updatedComments.length).toBeGreaterThanOrEqual(3);
+      const finalBody =
+        github.updatedComments[github.updatedComments.length - 1].body;
+      expect(finalBody).toContain("backported");
+      expect(finalBody).toContain(":white_check_mark: Created #100");
+      expect(finalBody).toContain(":white_check_mark: Created #101");
+    });
+
+    it("progressive updates show all-pending, then partial, then all-resolved", async () => {
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport main" }, { name: "backport release" }],
+        },
+      });
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      // Find the targets-known update (all pending, no completed rows)
+      const allPending = github.updatedComments.find(
+        (u) =>
+          u.body.includes(":hourglass:") &&
+          !u.body.includes(":white_check_mark:"),
+      );
+      expect(allPending).toBeDefined();
+
+      // Find partial update (one completed, one pending)
+      const partial = github.updatedComments.find(
+        (u) =>
+          u.body.includes(":white_check_mark:") &&
+          u.body.includes(":hourglass:"),
+      );
+      expect(partial).toBeDefined();
+
+      // Final update has both completed, no pending rows
+      const final = github.updatedComments[github.updatedComments.length - 1];
+      expect(final.body).toContain(":white_check_mark: Created #100");
+      expect(final.body).toContain(":white_check_mark: Created #101");
+      expect(final.body).not.toContain(":hourglass:");
+    });
+
+    it("failing target: final comment has details block with recovery instructions", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit({
+        cherryPick: vi.fn().mockRejectedValue(new Error("cherry-pick failed")),
+      });
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      const final =
+        github.updatedComments[github.updatedComments.length - 1].body;
+      expect(final).toContain(":x: Failed");
+      expect(final).toContain("<details>");
+      expect(final).toContain("unable to cherry-pick");
+    });
+
+    it("skipped target (PR already exists): summary cell shows skipped", async () => {
+      const github = new FakeGithub({
+        existingPRBranches: ["backport-42-to-main"],
+      });
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      const final =
+        github.updatedComments[github.updatedComments.length - 1].body;
+      expect(final).toContain(":heavy_minus_sign: Skipped");
+      expect(final).toContain("PR already exists");
+    });
+
+    it("no targets: comment is updated to 'backported' with no table", async () => {
+      const github = new FakeGithub({
+        sourcePr: { labels: [{ name: "bug" }] },
+      });
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      const final =
+        github.updatedComments[github.updatedComments.length - 1].body;
+      expect(final).toContain("backported this pull request");
+      expect(final).not.toContain("| Target |");
+    });
+
+    it("unmerged PR: comment is updated to 'failed to backport' with error", async () => {
+      const github = new FakeGithub({ merged: false });
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      const final =
+        github.updatedComments[github.updatedComments.length - 1].body;
+      expect(final).toContain("failed to backport this pull request");
+      expect(final).toContain("Only merged pull requests");
+    });
+
+    it("comment creation failure: backport still succeeds", async () => {
+      const github = new FakeGithub();
+      github.failOn("createComment", new Error("comment creation failed"));
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs).toHaveLength(1);
+      expect(core.setOutput).toHaveBeenCalledWith("was_successful", true);
+    });
+
+    it("comment update failure: backport still succeeds", async () => {
+      const github = new FakeGithub();
+      github.failOn("updateComment", new Error("update failed"));
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs).toHaveLength(1);
+      expect(core.setOutput).toHaveBeenCalledWith("was_successful", true);
+    });
+
+    it("outputs are correct on the success path", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit();
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(core.setOutput).toHaveBeenCalledWith("was_successful", true);
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "was_successful_by_target",
+        expect.stringContaining("main=true"),
+      );
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "created_pull_numbers",
+        "100",
+      );
+    });
+  });
 });

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -23,9 +23,8 @@ const context: CommentContext = {
 function failed(
   targetBranch: string,
   error: Error,
-  branchname?: string,
 ): Extract<TargetResult, { status: "failed" }> {
-  return { status: "failed", targetBranch, error, branchname };
+  return { status: "failed", targetBranch, error };
 }
 
 describe("formatSingleTargetComment", () => {
@@ -316,16 +315,6 @@ describe("formatRunComment", () => {
     expect(out).not.toContain("is backporting");
     expect(out).not.toContain("| Target |");
   });
-});
-
-describe("formatInitialComment", () => {
-  it("renders the early-run placeholder", () => {
-    const out = formatInitialComment(context);
-
-    expect(out).toContain("is backporting this pull request");
-    expect(out).toContain("workflow run 12345");
-    expect(out).not.toContain("| Target |");
-  });
 
   it("error with empty pendingTargets: intro + error message, no table", () => {
     const out = formatRunComment(
@@ -382,5 +371,15 @@ describe("formatInitialComment", () => {
 
     expect(out).toContain(":warning: Drafted with conflicts #200");
     expect(out).not.toContain("<details>");
+  });
+});
+
+describe("formatInitialComment", () => {
+  it("renders the early-run placeholder", () => {
+    const out = formatInitialComment(context);
+
+    expect(out).toContain("is backporting this pull request");
+    expect(out).toContain("workflow run 12345");
+    expect(out).not.toContain("| Target |");
   });
 });

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  CommentContext,
+  formatRunComment,
+  formatSingleTargetComment,
+} from "../comments.js";
+import {
+  CheckoutError,
+  CherryPickError,
+  CreatePRError,
+  GitPushError,
+  TargetResult,
+} from "../errors.js";
+import { GitRefNotFoundError } from "../git.js";
+
+const context: CommentContext = {
+  runId: "12345",
+  runUrl: "https://github.com/owner/repo/actions/runs/12345",
+};
+
+function failed(
+  targetBranch: string,
+  error: Error,
+  branchname?: string,
+): Extract<TargetResult, { status: "failed" }> {
+  return { status: "failed", targetBranch, error, branchname };
+}
+
+describe("formatSingleTargetComment", () => {
+  it("CheckoutError: includes backport branch and commit SHAs", () => {
+    const out = formatSingleTargetComment(
+      failed(
+        "main",
+        new CheckoutError("checkout failed", "backport-42-to-main", [
+          "sha1",
+          "sha2",
+        ]),
+      ),
+      context,
+    );
+
+    expect(out).toContain("unable to create backport branch");
+    expect(out).toContain("backport-42-to-main");
+    expect(out).toContain("sha1 sha2");
+    expect(out).toContain("main");
+  });
+
+  it("CherryPickError: includes failed commit SHAs and branch", () => {
+    const out = formatSingleTargetComment(
+      failed(
+        "stable/8.0",
+        new CherryPickError("cherry-pick failed", "backport-42-to-8.0", [
+          "abc",
+          "def",
+        ]),
+      ),
+      context,
+    );
+
+    expect(out).toContain("unable to cherry-pick");
+    expect(out).toContain("stable/8.0");
+    expect(out).toContain("backport-42-to-8.0");
+    expect(out).toContain("abc def");
+  });
+
+  it("GitPushError: includes branch, remote, and exit code with PAT recovery", () => {
+    const out = formatSingleTargetComment(
+      failed(
+        "stable/7.8",
+        new GitPushError("push failed", "backport-42-to-7.8", "origin", 128),
+      ),
+      context,
+    );
+
+    expect(out).toContain("push failed");
+    expect(out).toContain("backport-42-to-7.8");
+    expect(out).toContain("origin");
+    expect(out).toContain("128");
+    expect(out).toContain("Personal Access Token");
+  });
+
+  it("CreatePRError: includes status and response message when available", () => {
+    const out = formatSingleTargetComment(
+      failed(
+        "main",
+        new CreatePRError("validation failed", 422, '{"message":"bad"}'),
+      ),
+      context,
+    );
+
+    expect(out).toContain("failed to create pull request");
+    expect(out).toContain("422");
+    expect(out).toContain('{"message":"bad"}');
+  });
+
+  it("GitRefNotFoundError: includes ref name", () => {
+    const out = formatSingleTargetComment(
+      failed("nonexistent", new GitRefNotFoundError("not found", "nonexistent")),
+      context,
+    );
+
+    expect(out).toContain("target branch not found");
+    expect(out).toContain("nonexistent");
+  });
+
+  it("plain Error: directs to workflow run logs", () => {
+    const out = formatSingleTargetComment(
+      failed("main", new Error("something broke")),
+      context,
+    );
+
+    expect(out).toContain("unexpected failure");
+    expect(out).toContain("workflow run logs");
+    expect(out).toContain("github.com/korthout/backport-action/issues");
+  });
+});
+
+describe("formatRunComment", () => {
+  it("single success: table renders with PR link in status cell", () => {
+    const results: TargetResult[] = [
+      {
+        status: "success",
+        targetBranch: "main",
+        newPrNumber: 123,
+        branchname: "backport-42-to-main",
+      },
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain("backported this pull request");
+    expect(out).toContain("workflow run 12345");
+    expect(out).toContain("| Target | Status |");
+    expect(out).toContain(":white_check_mark: Created #123");
+    expect(out).not.toContain("<details>");
+  });
+
+  it("multiple failed targets: one details block per failure, in table order", () => {
+    const results: TargetResult[] = [
+      failed(
+        "stable/8.0",
+        new CherryPickError("cp", "backport-42-to-8.0", ["abc"]),
+      ),
+      failed(
+        "stable/7.8",
+        new GitPushError("push", "backport-42-to-7.8", "origin", 128),
+      ),
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain("unable to cherry-pick");
+    expect(out).toContain("push failed");
+    // stable/8.0 details should appear before stable/7.8 details
+    expect(out.indexOf("unable to cherry-pick")).toBeLessThan(
+      out.indexOf("push failed"),
+    );
+  });
+
+  it("mix of statuses: only failures get details blocks", () => {
+    const results: TargetResult[] = [
+      {
+        status: "success",
+        targetBranch: "main",
+        newPrNumber: 100,
+        branchname: "b1",
+      },
+      failed(
+        "stable/8.0",
+        new CherryPickError("cp", "backport-42-to-8.0", ["abc"]),
+      ),
+      {
+        status: "skipped",
+        targetBranch: "stable/7.9",
+        reason: "PR already exists",
+      },
+    ];
+    const out = formatRunComment(results, ["stable/7.7"], context);
+
+    expect(out).toContain(":white_check_mark: Created #100");
+    expect(out).toContain(":x: Failed");
+    expect(out).toContain(":heavy_minus_sign: Skipped (PR already exists)");
+    expect(out).toContain(":hourglass: Pending");
+    // exactly one details block (the failed one)
+    expect(out.match(/<details>/g)).toHaveLength(1);
+  });
+
+  it("all targets completed (successes only): backported intro, no pending", () => {
+    const results: TargetResult[] = [
+      {
+        status: "success",
+        targetBranch: "main",
+        newPrNumber: 100,
+        branchname: "b1",
+      },
+      {
+        status: "success",
+        targetBranch: "stable/8.2",
+        newPrNumber: 101,
+        branchname: "b2",
+      },
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain("backported this pull request");
+    expect(out).not.toContain(":hourglass:");
+  });
+
+  it("all targets completed (all skipped): no details blocks", () => {
+    const results: TargetResult[] = [
+      { status: "skipped", targetBranch: "main", reason: "PR already exists" },
+      {
+        status: "skipped",
+        targetBranch: "stable/8.2",
+        reason: "PR already exists",
+      },
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain("backported this pull request");
+    expect(out).toContain(":heavy_minus_sign: Skipped");
+    expect(out).not.toContain("<details>");
+  });
+
+  it("all targets pending: progressive intro and all rows pending", () => {
+    const out = formatRunComment([], ["main", "stable/8.2"], context);
+
+    expect(out).toContain("is backporting this pull request");
+    expect(out).toContain(":hourglass: Pending");
+    expect(out.match(/:hourglass: Pending/g)).toHaveLength(2);
+  });
+
+  it("no targets (early run state): intro only, no table", () => {
+    const out = formatRunComment([], [], context);
+
+    expect(out).toContain("is backporting this pull request");
+    expect(out).not.toContain("| Target |");
+  });
+
+  it("error with empty pendingTargets: intro + error message, no table", () => {
+    const out = formatRunComment([], [], context, "Only merged pull requests can be backported.");
+
+    expect(out).toContain("failed to backport this pull request");
+    expect(out).toContain("Only merged pull requests");
+    expect(out).not.toContain("| Target |");
+  });
+
+  it("error with non-empty pendingTargets: intro + error + pending table", () => {
+    const out = formatRunComment(
+      [],
+      ["main", "stable/8.2"],
+      context,
+      "Could not resolve commits to cherry-pick.",
+    );
+
+    expect(out).toContain("failed to backport this pull request");
+    expect(out).toContain("Could not resolve commits");
+    expect(out).toContain(":hourglass: Pending");
+  });
+
+  it("table uses two columns: PR link merged into status cell", () => {
+    const results: TargetResult[] = [
+      {
+        status: "success",
+        targetBranch: "main",
+        newPrNumber: 123,
+        branchname: "b1",
+      },
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain("| Target | Status |");
+    expect(out).not.toContain("| PR |");
+  });
+
+  it("success_with_conflicts: warning emoji, PR link, no details block", () => {
+    const results: TargetResult[] = [
+      {
+        status: "success_with_conflicts",
+        targetBranch: "main",
+        newPrNumber: 200,
+        branchname: "b1",
+        uncommittedShas: ["abc"],
+      },
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain(":warning: Drafted with conflicts #200");
+    expect(out).not.toContain("<details>");
+  });
+});

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -151,12 +151,12 @@ describe("formatRunComment", () => {
     ];
     const out = formatRunComment(results, [], context);
 
-    expect(out).toContain("unable to cherry-pick");
-    expect(out).toContain("push failed");
-    // stable/8.0 details should appear before stable/7.8 details
-    expect(out.indexOf("unable to cherry-pick")).toBeLessThan(
-      out.indexOf("push failed"),
-    );
+    const detailsBlocks = out.match(/<details>[\s\S]*?<\/details>/g);
+    expect(detailsBlocks).toHaveLength(2);
+    expect(detailsBlocks![0]).toContain("stable/8.0");
+    expect(detailsBlocks![0]).toContain("unable to cherry-pick");
+    expect(detailsBlocks![1]).toContain("stable/7.8");
+    expect(detailsBlocks![1]).toContain("push failed");
   });
 
   it("all targets failed: intro is 'failed to backport'", () => {

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -160,6 +160,82 @@ describe("formatRunComment", () => {
     );
   });
 
+  it("all targets failed: intro is 'failed to backport'", () => {
+    const results: TargetResult[] = [
+      failed(
+        "stable/8.0",
+        new CherryPickError("cp", "backport-42-to-8.0", ["abc"]),
+      ),
+      failed(
+        "stable/7.8",
+        new GitPushError("push", "backport-42-to-7.8", "origin", 128),
+      ),
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain("failed to backport this pull request");
+    expect(out).not.toContain("completed backporting");
+    expect(out).not.toContain("is backporting");
+  });
+
+  it("mixed success and failure: intro reports completion with failures", () => {
+    const results: TargetResult[] = [
+      {
+        status: "success",
+        targetBranch: "main",
+        newPrNumber: 100,
+        branchname: "b1",
+      },
+      failed(
+        "stable/8.0",
+        new CherryPickError("cp", "backport-42-to-8.0", ["abc"]),
+      ),
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain(
+      "completed backporting this pull request with failures",
+    );
+    expect(out).not.toContain("failed to backport");
+  });
+
+  it("failure mixed with skip: intro reports completion with failures", () => {
+    const results: TargetResult[] = [
+      failed(
+        "stable/8.0",
+        new CherryPickError("cp", "backport-42-to-8.0", ["abc"]),
+      ),
+      {
+        status: "skipped",
+        targetBranch: "stable/7.9",
+        reason: "PR already exists",
+      },
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain(
+      "completed backporting this pull request with failures",
+    );
+    expect(out).not.toContain("failed to backport");
+  });
+
+  it("success_with_conflicts is not a failure for intro wording", () => {
+    const results: TargetResult[] = [
+      {
+        status: "success_with_conflicts",
+        targetBranch: "main",
+        newPrNumber: 200,
+        branchname: "b1",
+        uncommittedShas: ["abc"],
+      },
+    ];
+    const out = formatRunComment(results, [], context);
+
+    expect(out).toContain("backported this pull request");
+    expect(out).not.toContain("with failures");
+    expect(out).not.toContain("failed to backport");
+  });
+
   it("mix of statuses: only failures get details blocks", () => {
     const results: TargetResult[] = [
       {

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   CommentContext,
+  formatInitialComment,
   formatRunComment,
   formatSingleTargetComment,
 } from "../comments.js";
@@ -96,7 +97,10 @@ describe("formatSingleTargetComment", () => {
 
   it("GitRefNotFoundError: includes ref name", () => {
     const out = formatSingleTargetComment(
-      failed("nonexistent", new GitRefNotFoundError("not found", "nonexistent")),
+      failed(
+        "nonexistent",
+        new GitRefNotFoundError("not found", "nonexistent"),
+      ),
       context,
     );
 
@@ -229,15 +233,31 @@ describe("formatRunComment", () => {
     expect(out.match(/:hourglass: Pending/g)).toHaveLength(2);
   });
 
-  it("no targets (early run state): intro only, no table", () => {
+  it("no targets and not pending: intro is 'backported', no table", () => {
     const out = formatRunComment([], [], context);
 
+    expect(out).toContain("backported this pull request");
+    expect(out).not.toContain("is backporting");
+    expect(out).not.toContain("| Target |");
+  });
+});
+
+describe("formatInitialComment", () => {
+  it("renders the early-run placeholder", () => {
+    const out = formatInitialComment(context);
+
     expect(out).toContain("is backporting this pull request");
+    expect(out).toContain("workflow run 12345");
     expect(out).not.toContain("| Target |");
   });
 
   it("error with empty pendingTargets: intro + error message, no table", () => {
-    const out = formatRunComment([], [], context, "Only merged pull requests can be backported.");
+    const out = formatRunComment(
+      [],
+      [],
+      context,
+      "Only merged pull requests can be backported.",
+    );
 
     expect(out).toContain("failed to backport this pull request");
     expect(out).toContain("Only merged pull requests");

--- a/src/test/helpers/config.ts
+++ b/src/test/helpers/config.ts
@@ -21,6 +21,7 @@ export function makeConfig(overrides?: Partial<Config>): Config {
     add_author_as_reviewer: false,
     auto_merge_enabled: false,
     auto_merge_method: "merge",
+    comment_style: "legacy",
     experimental: { conflict_resolution: "fail" },
     ...overrides,
   };

--- a/src/test/helpers/fake-github.ts
+++ b/src/test/helpers/fake-github.ts
@@ -77,7 +77,9 @@ export class FakeGithub implements GithubApi {
   private _failures = new Map<keyof GithubApi, Error>();
 
   readonly createdPRs: Array<CreatePullRequest & { number: number }> = [];
-  readonly comments: Comment[] = [];
+  readonly comments: Array<Comment & { id: number }> = [];
+  readonly updatedComments: Array<{ comment_id: number; body: string }> = [];
+  private _nextCommentId = 1000;
   readonly labelsByPR = new Map<number, string[]>();
   readonly assigneesByPR = new Map<number, string[]>();
   readonly reviewersByPR = new Map<number, string[]>();
@@ -155,10 +157,18 @@ export class FakeGithub implements GithubApi {
     return this._mergeStrategyResult;
   }
 
-  async createComment(comment: Comment): Promise<{}> {
+  async createComment(comment: Comment): Promise<number> {
     if (this._failures.has("createComment"))
       throw this._failures.get("createComment")!;
-    this.comments.push(comment);
+    const id = this._nextCommentId++;
+    this.comments.push({ ...comment, id });
+    return id;
+  }
+
+  async updateComment(comment_id: number, body: string): Promise<{}> {
+    if (this._failures.has("updateComment"))
+      throw this._failures.get("updateComment")!;
+    this.updatedComments.push({ comment_id, body });
     return {};
   }
 


### PR DESCRIPTION
## Summary

Add a new `comment_style: summary` option that posts a single progressive comment on the source PR instead of individual comments per target branch. The comment is created immediately when the action starts and updated in-place as each target is processed.

### Example comment

This is what the summary comment looks like mid-run, with a mix of results:

---

[Backport-action](https://github.com/korthout/backport-action) is backporting this pull request in [workflow run 15439584062](https://github.com/korthout/backport-action/actions/runs/15439584062).

| Target | Status |
|--------|--------|
| `stable/8.7` | :white_check_mark: Created #612 |
| `stable/8.6` | :warning: Drafted with conflicts #613 |
| `stable/8.5` | :x: Failed |
| `stable/8.4` | :heavy_minus_sign: Skipped (PR already exists) |
| `stable/8.3` | :hourglass: Pending |

<details><summary>:x: stable/8.5 — unable to cherry-pick</summary>

Tried to cherry-pick commits onto `stable/8.5`, but the cherry-pick failed.

Please cherry-pick the changes locally and resolve any conflicts.
```bash
git fetch origin stable/8.5
git worktree add -d .worktree/stable/8.5 origin/stable/8.5
cd .worktree/stable/8.5
git switch --create <backport-branch-name>
git cherry-pick -x a1b2c3d e4f5g6h
```

</details>

---

The introduction text changes with progress: "is backporting" while pending, "backported" when complete, or "failed to backport" on pre-loop errors.

### Graceful degradation

Comment create/update failures are logged but do not abort the backport.

## Stacked on

- #610 (refactoring)

## Test plan

- [x] All 125 tests pass (`npm test`)
- [x] New unit tests for comment formatting
- [x] New integration tests for summary comment orchestration
- [x] E2E test in korthout/backport-action-test with `comment_style: summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)