### PR TITLE
Use PAT for PR info workflow comments

### DIFF
--- a/.github/workflows/pr-info.yml
+++ b/.github/workflows/pr-info.yml
@@ -4,9 +4,6 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  issues: write
-
 jobs:
   comment:
     runs-on: ubuntu-latest
@@ -14,6 +11,7 @@ jobs:
       - name: Post merge instructions
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          github-token: ${{ secrets.BACKPORT_ACTION_PAT }}
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);
             const author = context.payload.pull_request.user.login;


### PR DESCRIPTION
## Summary
- The PR info workflow has been failing with 403 on every run since it was introduced
- `GITHUB_TOKEN` with `issues: write` should suffice per [GitHub docs](https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment), but a [known bug](https://github.com/orgs/community/discussions/191524) causes 403 errors when posting PR comments on branches protected by rulesets
- Work around this by using `BACKPORT_ACTION_PAT` instead of `GITHUB_TOKEN`
- This can be reverted once the upstream bug is resolved

## Test plan
- [ ] Verify the PR info workflow succeeds on a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)