### PR TITLE
Skip PR info comment on Mergify merge queue PRs

### DIFF
--- a/.github/workflows/pr-info.yml
+++ b/.github/workflows/pr-info.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   comment:
+    if: github.event.pull_request.user.login != 'mergify[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Post merge instructions


### PR DESCRIPTION
## Summary
- Skip posting merge instructions on PRs created by `mergify[bot]` (merge queue draft PRs)
- These PRs already contain Mergify's own description and will be closed automatically

## Test plan
- [ ] Verify PR info comment is still posted on regular PRs
- [ ] Verify PR info comment is skipped on Mergify merge queue PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)