### PR TITLE
Enable summary comment style for our own backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,3 +27,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create backport pull requests
         uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # v4.5.0
+        with:
+          comment_style: summary


### PR DESCRIPTION
## Summary
- Opts this repo's own backport workflow into the new `comment_style: summary` input introduced in v4.5.0.
- Exercises the progressive-update path against the real GitHub API on every backport this repo runs, so regressions surface here first.

## Test plan
- [ ] On the next backport (merge of a labelled PR, or a `/backport` comment), confirm a single summary comment is posted on the source PR and updated in-place as targets resolve.
- [ ] Confirm the workflow run link in the comment points back to the run that produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)