### PR TITLE
fix(comment): defer summary comment creation until first update

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -8,11 +8,7 @@ import {
 } from "./github.js";
 import { GithubApi } from "./github.js";
 import { GitApi, GitRefNotFoundError } from "./git.js";
-import {
-  CommentContext,
-  formatInitialComment,
-  formatRunComment,
-} from "./comments.js";
+import { CommentContext, formatRunComment } from "./comments.js";
 import {
   CheckoutError,
   CherryPickError,
@@ -172,26 +168,27 @@ export class Backport {
         runUrl: this.github.getRunUrl(),
       };
 
-      // For the summary style, create the placeholder comment as early as
-      // possible (before validating the PR) so we can update it with errors
-      // even if validation fails. Comment creation is best-effort: on
-      // failure we log and continue without commenting.
+      // For the summary style we lazily create the placeholder comment on
+      // the first call to updateSummary. Creating it upfront caused #629:
+      // when the merged PR carries no labels matching the backport pattern,
+      // the "no target branches" early return left an empty summary
+      // comment on every merged PR.
       let summaryCommentId: number | undefined;
-      if (isSummary) {
-        try {
-          summaryCommentId = await this.github.createComment({
-            owner: workflowOwner,
-            repo: workflowRepo,
-            issue_number: pull_number,
-            body: formatInitialComment(commentCtx),
-          });
-        } catch (error) {
-          console.error("Failed to create summary comment:", error);
-        }
-      }
-
       const updateSummary = async (body: string) => {
-        if (summaryCommentId === undefined) return;
+        if (!isSummary) return;
+        if (summaryCommentId === undefined) {
+          try {
+            summaryCommentId = await this.github.createComment({
+              owner: workflowOwner,
+              repo: workflowRepo,
+              issue_number: pull_number,
+              body,
+            });
+          } catch (error) {
+            console.error("Failed to create summary comment:", error);
+          }
+          return;
+        }
         try {
           await this.github.updateComment(summaryCommentId, body);
         } catch (error) {
@@ -219,11 +216,9 @@ export class Backport {
         console.log(
           `Nothing to backport: no 'target_branches' specified and none of the labels match the backport pattern '${this.config.source_labels_pattern?.source}'`,
         );
-        if (isSummary) {
-          // No targets to backport — update to the "backported" wording
-          // with no table. This is not a failure.
-          await updateSummary(formatRunComment([], [], commentCtx));
-        }
+        // Don't create a summary comment for the no-targets path — there
+        // is nothing meaningful to report and the comment would be added
+        // noise on every merged PR that does not opt into a backport.
         return; // nothing left to do here
       }
 

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -681,7 +681,7 @@ describe("Backport.run() orchestration", () => {
   });
 
   describe("comment_style: summary", () => {
-    it("creates a single comment up front and updates it after each target", async () => {
+    it("lazily creates one comment with the targets-known body and updates it after each target", async () => {
       const github = new FakeGithub({
         sourcePr: {
           labels: [{ name: "backport main" }, { name: "backport release" }],
@@ -693,10 +693,11 @@ describe("Backport.run() orchestration", () => {
       await backport.run();
 
       expect(github.comments).toHaveLength(1);
-      expect(github.comments[0].body).toContain("is backporting");
+      // First update is the create itself, body shows targets pending.
+      expect(github.comments[0].body).toContain(":hourglass:");
 
-      // Initial create + targets-known update + 2 per-target updates = 3 updates
-      expect(github.updatedComments.length).toBeGreaterThanOrEqual(3);
+      // Two per-target updates after the create
+      expect(github.updatedComments.length).toBeGreaterThanOrEqual(2);
 
       // Every update targets the comment that was created
       const id = github.comments[0].id;
@@ -725,13 +726,10 @@ describe("Backport.run() orchestration", () => {
       const countMatches = (body: string, marker: string) =>
         (body.match(new RegExp(marker, "g")) ?? []).length;
 
-      // Targets-known update: both rows pending, no completed rows
-      const allPending = github.updatedComments.find(
-        (u) =>
-          countMatches(u.body, ":hourglass:") === 2 &&
-          !u.body.includes(":white_check_mark:"),
-      );
-      expect(allPending).toBeDefined();
+      // First state is the create itself: both rows pending, no completed rows.
+      const allPendingBody = github.comments[0].body;
+      expect(countMatches(allPendingBody, ":hourglass:")).toBe(2);
+      expect(allPendingBody).not.toContain(":white_check_mark:");
 
       // Partial update: exactly one completed, exactly one pending
       const partial = github.updatedComments.find(
@@ -779,7 +777,7 @@ describe("Backport.run() orchestration", () => {
       expect(final).toContain("PR already exists");
     });
 
-    it("no targets: comment is updated to 'backported' with no table", async () => {
+    it("no targets: no summary comment is created (#629)", async () => {
       const github = new FakeGithub({
         sourcePr: { labels: [{ name: "bug" }] },
       });
@@ -788,23 +786,27 @@ describe("Backport.run() orchestration", () => {
       const backport = new Backport(github, config, git);
       await backport.run();
 
-      const final =
-        github.updatedComments[github.updatedComments.length - 1].body;
-      expect(final).toContain("backported this pull request");
-      expect(final).not.toContain("| Target |");
+      // Comment must not be created at all when there are no target
+      // branches — the previous behaviour left an empty "backported"
+      // comment on every merged PR that did not opt into a backport.
+      expect(github.comments).toHaveLength(0);
+      expect(github.updatedComments).toHaveLength(0);
     });
 
-    it("unmerged PR: comment is updated to 'failed to backport' with error", async () => {
+    it("unmerged PR: lazy-creates the comment with the 'failed to backport' body", async () => {
       const github = new FakeGithub({ merged: false });
       const git = createMockGit();
       const config = makeConfig({ comment_style: "summary" });
       const backport = new Backport(github, config, git);
       await backport.run();
 
-      const final =
-        github.updatedComments[github.updatedComments.length - 1].body;
+      // Comment is created (not updated) on the first updateSummary
+      // call, so the failure body should be in the create itself.
+      expect(github.comments).toHaveLength(1);
+      const final = github.comments[0].body;
       expect(final).toContain("failed to backport this pull request");
       expect(final).toContain("Only merged pull requests");
+      expect(github.updatedComments).toHaveLength(0);
     });
 
     it("comment creation failure: backport still succeeds", async () => {


### PR DESCRIPTION
## Summary

Closes #629.

The `summary` comment style created its placeholder comment as the very first action step (`src/backport.ts:180–191`), before `findTargetBranches` ran. When a merged PR carried no labels matching the backport pattern, the `target_branches.length === 0` early return then *updated* the placeholder to the "backported" wording with no table — leaving an empty no-op comment on every merged PR that didn't opt into a backport.

## Fix

Lazily create the summary comment from `updateSummary`:

* `updateSummary`'s first call creates the comment with the body it was given; subsequent calls update that comment in place. Same callers as before, no other refactor needed.
* The no-target-branches path no longer calls `updateSummary` at all, so a PR that opted out of backport never gets a summary comment.
* The unmerged-PR and per-target paths still post the comment exactly as before, but with the actual status as the create body, removing one round-trip.
* The now-unused `formatInitialComment` import is dropped.

## Tests

* New: `lazily creates one comment with the targets-known body and updates it after each target` replaces the old `creates a single comment up front` case.
* New: `no targets: no summary comment is created (#629)` asserts `github.comments` and `github.updatedComments` are both empty.
* Updated: the unmerged-PR test now asserts the failure body is on the created comment, not on a follow-up update.
* Updated: the progressive-updates test reads the all-pending state from `github.comments[0].body` (the create) rather than from the first `updatedComments` entry.

`vitest run src/test/backport.integration.test.ts` → 47 / 47 passing
`vitest run src/test/backport.test.ts src/test/comments.test.ts src/test/utils.test.ts` → 65 / 65 passing
`tsc` → clean