### PR TITLE
Post resolve-conflicts comment on draft PR in summary mode

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -586,19 +586,28 @@ export class Backport {
     });
 
     if (result.status === "success_with_conflicts") {
-      const conflictMessage = composeMessageToResolveCommittedConflicts(
-        targetBranch,
-        branchname,
-        result.uncommittedShas,
-        this.config.experimental.conflict_resolution,
-      );
-      await this.github.createComment({
-        owner: targetOwner,
-        repo: targetRepo,
-        issue_number: newPrNumber,
-        body: conflictMessage,
-      });
+      await this.commentResolveConflictsOnDraftPr(result, context);
     }
+  }
+
+  private async commentResolveConflictsOnDraftPr(
+    result: Extract<TargetResult, { status: "success_with_conflicts" }>,
+    context: BackportContext,
+  ): Promise<void> {
+    const { targetOwner, targetRepo } = context;
+    const { targetBranch, newPrNumber, branchname } = result;
+    const conflictMessage = composeMessageToResolveCommittedConflicts(
+      targetBranch,
+      branchname,
+      result.uncommittedShas,
+      this.config.experimental.conflict_resolution,
+    );
+    await this.github.createComment({
+      owner: targetOwner,
+      repo: targetRepo,
+      issue_number: newPrNumber,
+      body: conflictMessage,
+    });
   }
 
   private composePRContent(target: string, main: PullRequest): PRContent {

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -318,6 +318,19 @@ export class Backport {
           await updateSummary(
             formatRunComment(results, remainingTargets, commentCtx),
           );
+          if (result.status === "success_with_conflicts") {
+            // Best-effort: a failure to post the resolve-conflicts comment
+            // shouldn't flip a success_with_conflicts target into a hard run
+            // failure or block subsequent targets.
+            try {
+              await this.commentResolveConflictsOnDraftPr(result, context);
+            } catch (error) {
+              console.error(
+                "Failed to post resolve-conflicts comment on draft PR:",
+                error,
+              );
+            }
+          }
         } else {
           await this.handleTargetResultLegacy(result, context);
         }

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -831,6 +831,39 @@ describe("Backport.run() orchestration", () => {
       expect(core.setOutput).toHaveBeenCalledWith("was_successful", true);
     });
 
+    it("conflicts with draft_commit_conflicts: comments on the draft PR with resolve-conflicts instructions", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit({
+        // non-null array signals which SHAs still need to be cherry-picked as there were conflicts encountered
+        cherryPick: vi.fn().mockResolvedValue(["abc123"]),
+      });
+      const config = makeConfig({
+        comment_style: "summary",
+        experimental: { conflict_resolution: "draft_commit_conflicts" },
+      });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs).toHaveLength(1);
+      expect(github.createdPRs[0].draft).toBe(true);
+
+      const draftPrComments = github.comments.filter(
+        (c) => c.issue_number === 100,
+      );
+      expect(draftPrComments).toHaveLength(1);
+      const body = draftPrComments[0].body;
+      expect(body).toContain(
+        "Please cherry-pick the changes locally and resolve any conflicts",
+      );
+      expect(body).toContain("git fetch origin backport-42-to-main");
+      expect(body).toContain(
+        "git worktree add --checkout .worktree/backport-42-to-main backport-42-to-main",
+      );
+      expect(body).toContain("cd .worktree/backport-42-to-main");
+      expect(body).toContain("git reset --hard HEAD^");
+      expect(body).toContain("git cherry-pick -x abc123");
+    });
+
     it("outputs are correct on the success path", async () => {
       const github = new FakeGithub();
       const git = createMockGit();

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -864,6 +864,25 @@ describe("Backport.run() orchestration", () => {
       expect(body).toContain("git cherry-pick -x abc123");
     });
 
+    it("draft-PR comment failure: backport still succeeds in summary mode", async () => {
+      const github = new FakeGithub();
+      github.failOn("createComment", new Error("create failed"));
+      const git = createMockGit({
+        // non-null array signals which SHAs still need to be cherry-picked as there were conflicts encountered
+        cherryPick: vi.fn().mockResolvedValue(["abc123"]),
+      });
+      const config = makeConfig({
+        comment_style: "summary",
+        experimental: { conflict_resolution: "draft_commit_conflicts" },
+      });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs).toHaveLength(1);
+      expect(github.createdPRs[0].draft).toBe(true);
+      expect(core.setOutput).toHaveBeenCalledWith("was_successful", true);
+    });
+
     it("outputs are correct on the success path", async () => {
       const github = new FakeGithub();
       const git = createMockGit();


### PR DESCRIPTION
## Summary

- Restores the draft-PR resolve-conflicts comment when `comment_style: summary` is paired with `experimental.conflict_resolution: draft_commit_conflicts`. Previously, the legacy comment branch was skipped on the summary path, leaving users with a draft backport PR and no recovery instructions.
- Reuses the existing `composeMessageToResolveCommittedConflicts` so legacy and summary modes produce the same recipe — deliberately scoped to "restore missing functionality" rather than redesigning the message. An improved message (e.g. a `cherry-pick --continue` instruction) would benefit both modes and belongs in a separate change.

Closes #633

## Test plan

- [x] `npm run all` passes locally (131/131 tests)
- [ ] On a real PR with `comment_style: summary` + `experimental.conflict_resolution: draft_commit_conflicts`, verify the draft backport PR receives the resolve-conflicts comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
