### PR TITLE
Report no-targets outcome and recommend a workflow filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ jobs:
   backport:
     name: Backport pull request
     runs-on: ubuntu-latest
-    # Don't run on closed unmerged pull requests
-    if: github.event.pull_request.merged
+    # Only run on merged PRs with a backport label (default `label_pattern`)
+    if: >
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
     steps:
       - uses: actions/checkout@v4
       - name: Create backport pull requests
@@ -80,14 +82,14 @@ jobs:
     name: Backport pull request
     runs-on: ubuntu-latest
 
-    # Only run when pull request is merged
-    # or when a comment starting with `/backport` is created by someone other than the
-    # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
-    # own PAT as `github_token`, that you should replace this id with yours.
+    # Run on merged PRs with a backport label (default `label_pattern`),
+    # or on `/backport` comments from a non-bot user (id 97796249 is the
+    # backport-action bot; replace with your PAT's user id if applicable).
     if: >
       (
         github.event_name == 'pull_request_target' &&
-        github.event.pull_request.merged
+        github.event.pull_request.merged &&
+        contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -11,6 +11,7 @@ import { GitApi, GitRefNotFoundError } from "./git.js";
 import {
   CommentContext,
   formatInitialComment,
+  formatNoTargetsComment,
   formatRunComment,
 } from "./comments.js";
 import {
@@ -220,9 +221,7 @@ export class Backport {
           `Nothing to backport: no 'target_branches' specified and none of the labels match the backport pattern '${this.config.source_labels_pattern?.source}'`,
         );
         if (isSummary) {
-          // No targets to backport — update to the "backported" wording
-          // with no table. This is not a failure.
-          await updateSummary(formatRunComment([], [], commentCtx));
+          await updateSummary(formatNoTargetsComment(commentCtx));
         }
         return; // nothing left to do here
       }

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -89,6 +89,21 @@ export function formatInitialComment(context: CommentContext): string {
   return `${ACTION_LINK} is backporting this pull request in ${runLink}.`;
 }
 
+/**
+ * Body for the terminal "no target branches found" outcome. The action ran,
+ * determined there was nothing to backport, and stopped — neither a success
+ * nor a failure, so it gets its own wording instead of being squeezed into
+ * `formatRunComment`.
+ */
+export function formatNoTargetsComment(context: CommentContext): string {
+  const runLink = `[workflow run ${context.runId}](${context.runUrl})`;
+  return dedent`${ACTION_LINK} found no target branches to backport this pull request to in ${runLink}.
+
+                This can happen when the pull request has no labels matching \`label_pattern\`, or when no \`target_branches\` were configured.
+
+                To avoid unnecessary action runs, update your workflow so this action only runs for PRs that should be backported, such as PRs with a matching backport label or runs with explicit \`target_branches\`.`;
+}
+
 function formatTable(
   results: TargetResult[],
   pendingTargets: string[],

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -779,7 +779,7 @@ describe("Backport.run() orchestration", () => {
       expect(final).toContain("PR already exists");
     });
 
-    it("no targets: comment is updated to 'backported' with no table", async () => {
+    it("no targets: comment explains nothing was backported, not success", async () => {
       const github = new FakeGithub({
         sourcePr: { labels: [{ name: "bug" }] },
       });
@@ -790,7 +790,18 @@ describe("Backport.run() orchestration", () => {
 
       const final =
         github.updatedComments[github.updatedComments.length - 1].body;
-      expect(final).toContain("backported this pull request");
+      // Must not imply success or failure: the action did not attempt a backport.
+      expect(final).not.toContain("backported this pull request");
+      expect(final).not.toContain("failed to backport");
+      expect(final).toContain(
+        "found no target branches to backport this pull request to",
+      );
+      expect(final).toContain(
+        "This can happen when the pull request has no labels matching `label_pattern`, or when no `target_branches` were configured.",
+      );
+      expect(final).toContain(
+        "To avoid unnecessary action runs, update your workflow so this action only runs for PRs that should be backported, such as PRs with a matching backport label or runs with explicit `target_branches`.",
+      );
       expect(final).not.toContain("| Target |");
     });
 

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   CommentContext,
   formatInitialComment,
+  formatNoTargetsComment,
   formatRunComment,
   formatSingleTargetComment,
 } from "../comments.js";
@@ -308,14 +309,6 @@ describe("formatRunComment", () => {
     expect(out.match(/:hourglass: Pending/g)).toHaveLength(2);
   });
 
-  it("no targets and not pending: intro is 'backported', no table", () => {
-    const out = formatRunComment([], [], context);
-
-    expect(out).toContain("backported this pull request");
-    expect(out).not.toContain("is backporting");
-    expect(out).not.toContain("| Target |");
-  });
-
   it("error with empty pendingTargets: intro + error message, no table", () => {
     const out = formatRunComment(
       [],
@@ -371,6 +364,47 @@ describe("formatRunComment", () => {
 
     expect(out).toContain(":warning: Drafted with conflicts #200");
     expect(out).not.toContain("<details>");
+  });
+});
+
+describe("formatNoTargetsComment", () => {
+  it("does not claim the PR was backported or that backport failed", () => {
+    const out = formatNoTargetsComment(context);
+
+    expect(out).not.toContain("backported this pull request");
+    expect(out).not.toContain("failed to backport");
+    expect(out).not.toContain("is backporting");
+  });
+
+  it("intro states no target branches were found and links the run", () => {
+    const out = formatNoTargetsComment(context);
+
+    expect(out).toContain(
+      `[Backport-action](https://github.com/korthout/backport-action) found no target branches to backport this pull request to in [workflow run ${context.runId}](${context.runUrl}).`,
+    );
+  });
+
+  it("explains the two reasons no targets were found", () => {
+    const out = formatNoTargetsComment(context);
+
+    expect(out).toContain(
+      "This can happen when the pull request has no labels matching `label_pattern`, or when no `target_branches` were configured.",
+    );
+  });
+
+  it("hints at workflow-level filtering to avoid unnecessary runs", () => {
+    const out = formatNoTargetsComment(context);
+
+    expect(out).toContain(
+      "To avoid unnecessary action runs, update your workflow so this action only runs for PRs that should be backported, such as PRs with a matching backport label or runs with explicit `target_branches`.",
+    );
+  });
+
+  it("renders no result table", () => {
+    const out = formatNoTargetsComment(context);
+
+    expect(out).not.toContain("| Target |");
+    expect(out).not.toContain(":hourglass: Pending");
   });
 });
 


### PR DESCRIPTION
Closes #629.

## Summary
- Report no-targets runs with explicit wording in the summary comment, instead of the misleading "Successfully created backport PRs".
- The new comment hints that users avoid unnecessary action runs by filtering at the workflow layer (label match or explicit `target_branches`).
- Update both README workflow examples to demonstrate that recommended label-prefix filter, so the in-comment hint lands on a doc that shows the pattern.

## Why the chosen filter expression
`contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')` anchors to the start of a label name (each entry is JSON-quoted), so a stray label like `not-backport ...` won't match. The default `label_pattern` (`^backport ([^ ]+)$`) is the assumption, called out inline so users who customize it see the dependency.

The comment-trigger example deliberately keeps the `/backport` branch unfiltered: an explicit user comment is intent enough.

## Test plan
- [x] `npm run all` green
- [x] Render README on GitHub preview; both YAML blocks parse
- [ ] Spot-check filter behavior in a scratch repo (optional)
