### PR TITLE
Add opt-in whitespace-tolerant cherry-picking merge mode

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,10 @@ The new commits created on the target branch by `git cherry-pick`. The commit au
 **Merge method**:
 How a pull request is merged on GitHub. One of: squash-and-merge, rebase-and-merge, or merge commit. The action *observes* the original pull request's merge method (consumed by `cherry_picking: auto`) and *configures* the backport pull request's merge method (via `auto_merge_method`). Always disambiguate which pull request's merge method is meant.
 
+**Cherry-pick merge mode**:
+The action's abstraction over git's strategy options for `git cherry-pick`. Controlled via the `cherry_picking_merge_mode` input. Values are `default` (standard cherry-pick behavior) and `whitespace_tolerant` (trailing whitespace differences are ignored when cherry-picking). Not to be confused with the pull request's **merge method**.
+_Avoid_: "merge strategy option" (a git-internal term; this action redefines the concept for its own abstraction)
+
 **PR author**:
 The GitHub user who opened a pull request. The action can copy the original PR author to the backport PR as assignee or reviewer (`add_author_as_assignee`, `add_author_as_reviewer`, `pull_author` placeholder).
 _Avoid_: just "author" (collides with commit author)

--- a/README.md
+++ b/README.md
@@ -304,6 +304,18 @@ Specifically, those reachable from the pull request's head and not reachable fro
 
 By default, the action cherry-picks the commits based on the method used to merge the pull request.
 
+### `cherry_picking_merge_mode`
+
+Default: `default`
+
+Sets the merge strategy option for cherry-picking. Accepted values:
+`default` (standard cherry-pick behavior) or `whitespace_tolerant`
+(ignores trailing whitespace when matching context lines, equivalent
+to `git cherry-pick -Xignore-space-at-eol`). Use `whitespace_tolerant`
+when the target branch has diverged from the source branch only in
+trailing whitespace, which would otherwise cause cherry-pick conflicts
+or silent line duplication.
+
 ### `comment_style`
 
 Default: `legacy`

--- a/README.md
+++ b/README.md
@@ -314,7 +314,10 @@ Sets the merge strategy option for cherry-picking. Accepted values:
 to `git cherry-pick -Xignore-space-at-eol`). Use `whitespace_tolerant`
 when the target branch has diverged from the source branch only in
 trailing whitespace, which would otherwise cause cherry-pick conflicts
-or silent line duplication.
+— or, if your `.gitattributes` declares `merge=union` for the affected
+file type (a common Visual Studio convention for `.csproj`/`.sln`
+files), silently duplicated lines or references with no conflict to
+flag it.
 
 ### `comment_style`
 

--- a/README.md
+++ b/README.md
@@ -308,16 +308,14 @@ By default, the action cherry-picks the commits based on the method used to merg
 
 Default: `default`
 
-Sets the merge strategy option for cherry-picking. Accepted values:
+Controls the cherry-pick merge mode. Accepted values:
 `default` (standard cherry-pick behavior) or `whitespace_tolerant`
-(ignores trailing whitespace when matching context lines, equivalent
-to `git cherry-pick -Xignore-space-at-eol`). Use `whitespace_tolerant`
-when the target branch has diverged from the source branch only in
-trailing whitespace, which would otherwise cause cherry-pick conflicts
-— or, if your `.gitattributes` declares `merge=union` for the affected
-file type (a common Visual Studio convention for `.csproj`/`.sln`
-files), silently duplicated lines or references with no conflict to
-flag it.
+(ignores trailing whitespace and line-ending (CRLF vs LF) differences
+when applying the cherry-pick). Use `whitespace_tolerant` when those
+differences around the lines you're backporting cause cherry-pick
+conflicts. Also use it when `.gitattributes` declares `merge=union`
+for the file, where those same differences can silently duplicate
+lines instead. Equivalent to `git cherry-pick -Xignore-space-at-eol`.
 
 ### `comment_style`
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,16 @@ inputs:
 
       By default, the action cherry-picks the commits based on the method used to merge the pull request.
     default: auto
+  cherry_picking_merge_mode:
+    default: default
+    description: >
+      Sets the merge strategy option for cherry-picking. Accepted values:
+      `default` (standard cherry-pick behavior) or `whitespace_tolerant`
+      (ignores trailing whitespace when matching context lines, equivalent
+      to `git cherry-pick -Xignore-space-at-eol`). Use `whitespace_tolerant`
+      when the target branch has diverged from the source branch only in
+      trailing whitespace, which would otherwise cause cherry-pick conflicts
+      or silent line duplication.
   comment_style:
     description: >
       Controls the style of comments posted by the action.

--- a/action.yml
+++ b/action.yml
@@ -64,16 +64,14 @@ inputs:
   cherry_picking_merge_mode:
     default: default
     description: >
-      Sets the merge strategy option for cherry-picking. Accepted values:
+      Controls the cherry-pick merge mode. Accepted values:
       `default` (standard cherry-pick behavior) or `whitespace_tolerant`
-      (ignores trailing whitespace when matching context lines, equivalent
-      to `git cherry-pick -Xignore-space-at-eol`). Use `whitespace_tolerant`
-      when the target branch has diverged from the source branch only in
-      trailing whitespace, which would otherwise cause cherry-pick conflicts
-      — or, if your `.gitattributes` declares `merge=union` for the affected
-      file type (a common Visual Studio convention for `.csproj`/`.sln`
-      files), silently duplicated lines or references with no conflict to
-      flag it.
+      (ignores trailing whitespace and line-ending (CRLF vs LF) differences
+      when applying the cherry-pick). Use `whitespace_tolerant` when those
+      differences around the lines you're backporting cause cherry-pick
+      conflicts. Also use it when `.gitattributes` declares `merge=union`
+      for the file, where those same differences can silently duplicate
+      lines instead. Equivalent to `git cherry-pick -Xignore-space-at-eol`.
   comment_style:
     description: >
       Controls the style of comments posted by the action.

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,10 @@ inputs:
       to `git cherry-pick -Xignore-space-at-eol`). Use `whitespace_tolerant`
       when the target branch has diverged from the source branch only in
       trailing whitespace, which would otherwise cause cherry-pick conflicts
-      or silent line duplication.
+      — or, if your `.gitattributes` declares `merge=union` for the affected
+      file type (a common Visual Studio convention for `.csproj`/`.sln`
+      files), silently duplicated lines or references with no conflict to
+      flag it.
   comment_style:
     description: >
       Controls the style of comments posted by the action.

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -75,6 +75,7 @@ export type Config = {
   target_branches?: string;
   commits: {
     cherry_picking: "auto" | "pull_request_head";
+    cherry_picking_merge_mode: "default" | "whitespace_tolerant";
     merge_commits: "fail" | "skip";
   };
   copy_milestone: boolean;
@@ -412,12 +413,18 @@ export class Backport {
 
       let uncommittedShas: string[] | null;
 
+      if (
+        this.config.commits.cherry_picking_merge_mode === "whitespace_tolerant"
+      ) {
+        console.log("Cherry-picking with whitespace-tolerant merge.");
+      }
+
       try {
         uncommittedShas = await this.git.cherryPick(
           commitShasToCherryPick,
           this.config.experimental.conflict_resolution,
           this.config.pwd,
-          "default",
+          this.config.commits.cherry_picking_merge_mode,
         );
       } catch (error) {
         const message =

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -416,7 +416,7 @@ export class Backport {
       if (
         this.config.commits.cherry_picking_merge_mode === "whitespace_tolerant"
       ) {
-        console.log("Cherry-picking with whitespace-tolerant merge.");
+        console.log("Cherry-picking in whitespace-tolerant mode.");
       }
 
       try {

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -417,6 +417,7 @@ export class Backport {
           commitShasToCherryPick,
           this.config.experimental.conflict_resolution,
           this.config.pwd,
+          "default",
         );
       } catch (error) {
         const message =

--- a/src/git.ts
+++ b/src/git.ts
@@ -32,6 +32,7 @@ export interface GitApi {
     commitShas: string[],
     conflictResolution: string,
     pwd: string,
+    mergeMode: "default" | "whitespace_tolerant",
   ): Promise<string[] | null>;
 }
 
@@ -186,7 +187,11 @@ export class Git implements GitApi {
     commitShas: string[],
     conflictResolution: string,
     pwd: string,
+    mergeMode: "default" | "whitespace_tolerant",
   ): Promise<string[] | null> {
+    const strategyArgs =
+      mergeMode === "whitespace_tolerant" ? ["-Xignore-space-at-eol"] : [];
+
     const abortCherryPickAndThrow = async (
       commitShas: string[],
       exitCode: number,
@@ -200,7 +205,7 @@ export class Git implements GitApi {
     if (conflictResolution === `fail`) {
       const { exitCode } = await this.git(
         "cherry-pick",
-        ["-x", ...commitShas],
+        ["-x", ...strategyArgs, ...commitShas],
         pwd,
       );
 
@@ -216,7 +221,7 @@ export class Git implements GitApi {
       while (uncommittedShas.length > 0) {
         const { exitCode } = await this.git(
           "cherry-pick",
-          ["-x", uncommittedShas[0]],
+          ["-x", ...strategyArgs, uncommittedShas[0]],
           pwd,
         );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
 } from "./backport.js";
 import { Github } from "./github.js";
 import { Git } from "./git.js";
+import { coerceCherryPickingMergeMode } from "./utils.js";
 import dedent from "dedent";
 
 /**
@@ -27,6 +28,7 @@ async function run(): Promise<void> {
   const copy_labels_pattern = core.getInput("copy_labels_pattern");
   const target_branches = core.getInput("target_branches");
   const cherry_picking = core.getInput("cherry_picking");
+  const cherry_picking_merge_mode = core.getInput("cherry_picking_merge_mode");
   const merge_commits = core.getInput("merge_commits");
   const copy_assignees = core.getInput("copy_assignees");
   const copy_milestone = core.getInput("copy_milestone");
@@ -44,6 +46,16 @@ async function run(): Promise<void> {
 
   if (cherry_picking !== "auto" && cherry_picking !== "pull_request_head") {
     const message = `Expected input 'cherry_picking' to be either 'auto' or 'pull_request_head', but was '${cherry_picking}'`;
+    console.error(message);
+    core.setFailed(message);
+    return;
+  }
+
+  const coercedCherryPickingMergeMode = coerceCherryPickingMergeMode(
+    cherry_picking_merge_mode,
+  );
+  if (coercedCherryPickingMergeMode === "invalid") {
+    const message = `Invalid value for \`cherry_picking_merge_mode\`: \`${cherry_picking_merge_mode}\`. Accepted values: \`default\`, \`whitespace_tolerant\`.`;
     console.error(message);
     core.setFailed(message);
     return;
@@ -120,7 +132,11 @@ async function run(): Promise<void> {
       copy_labels_pattern === "" ? undefined : new RegExp(copy_labels_pattern),
     add_labels: add_labels === "" ? [] : add_labels.split(/[,]/),
     target_branches: target_branches === "" ? undefined : target_branches,
-    commits: { cherry_picking, merge_commits },
+    commits: {
+      cherry_picking,
+      cherry_picking_merge_mode: coercedCherryPickingMergeMode,
+      merge_commits,
+    },
     copy_assignees: copy_assignees === "true",
     copy_milestone: copy_milestone === "true",
     copy_all_reviewers: copy_all_reviewers === "true",

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -235,6 +235,7 @@ describe("Backport.run() orchestration", () => {
         ["sha1", "sha2"],
         expect.anything(),
         expect.anything(),
+        "default",
       );
     });
 

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -224,6 +224,7 @@ describe("Backport.run() orchestration", () => {
       const config = makeConfig({
         commits: {
           cherry_picking: "pull_request_head",
+          cherry_picking_merge_mode: "default",
           merge_commits: "fail",
         },
       });

--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -35,6 +35,8 @@ import {
   afterAll,
   afterEach,
 } from "vitest";
+import { readFile } from "fs/promises";
+import { join } from "path";
 import { devNull } from "os";
 import type { TestRepo } from "./helpers/test-repo.js";
 import { Backport } from "../backport.js";
@@ -590,6 +592,117 @@ describe("Backport.run() with real git", () => {
           },
         ],
       );
+    },
+  );
+});
+
+describe("cherry-pick whitespace-tolerant mode", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  let template: RepoTemplate;
+
+  beforeAll(async () => {
+    savedEnv.GIT_CONFIG_GLOBAL = process.env.GIT_CONFIG_GLOBAL;
+    savedEnv.GIT_CONFIG_NOSYSTEM = process.env.GIT_CONFIG_NOSYSTEM;
+    process.env.GIT_CONFIG_GLOBAL = devNull;
+    process.env.GIT_CONFIG_NOSYSTEM = "1";
+    template = await createRepoTemplate();
+  });
+
+  afterAll(async () => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await template.cleanup();
+  });
+
+  afterEach(async (ctx) => {
+    if (ctx.repo) await ctx.repo.cleanup();
+  });
+
+  function setupGit() {
+    return new Git("Test", "test@test.com", process.env.GIT_SILENT === "1");
+  }
+
+  it.concurrent(
+    // This test documents the #529 bug class: repos that declare
+    // `merge=union` for a path — the common Visual Studio convention for
+    // `.csproj`/`.sln` files — get silent content duplication when the
+    // target branch's context lines differ from the source parent only by
+    // trailing whitespace. Without a custom merge driver, this kind of
+    // divergence produces an explicit conflict; the union driver instead
+    // combines both sides of the unaligned hunk, so it keeps both the target
+    // branch's version of line2/line3 and the source's inserted content —
+    // the cherry-pick exits 0 with line2/line3 doubled in the file.
+    //
+    // This test fails red today because the resulting file content has
+    // those lines doubled. It goes green when whitespace-tolerant mode is
+    // wired in (Step 2), since -Xignore-space-at-eol lets the merge ignore
+    // the trailing-whitespace difference and align cleanly up front.
+    "default mode fails when context lines differ only by trailing whitespace (reproducer)",
+    async (ctx) => {
+      const repo = (ctx.repo = await template.createTestRepo());
+      const git = setupGit();
+
+      // Declare merge=union for feature.txt — the real-world trigger for
+      // #529.
+      await addCommit(
+        repo.workDir,
+        ".gitattributes",
+        "feature.txt merge=union\n",
+        "Add .gitattributes",
+      );
+      await pushBranch(repo.workDir);
+
+      // Shared ancestor commit on main: header/footer anchor lines on either
+      // side of line1-3, so both branches have common content to align on.
+      const baseSha = await addCommit(
+        repo.workDir,
+        "feature.txt",
+        "header\nline1\nline2\nline3\nfooter\n",
+        "Add feature.txt with initial content",
+      );
+      await pushBranch(repo.workDir);
+
+      // Create release branch from that shared ancestor, so feature.txt's
+      // history (and the .gitattributes) is common to both branches.
+      await createBranch(repo.workDir, "release", baseSha);
+
+      // On main: add line_new between line2 and line3 (the feature commit to
+      // backport).
+      const featureSha = await addCommit(
+        repo.workDir,
+        "feature.txt",
+        "header\nline1\nline2\nline_new\nline3\nfooter\n",
+        "Add line_new to feature.txt",
+      );
+      await pushBranch(repo.workDir);
+
+      // Switch to release so the cherry-pick lands there. Only the context
+      // lines adjacent to the insertion point gain trailing whitespace;
+      // header/line1/footer stay exact matches so the merge has anchors to
+      // align on.
+      await gitCmd("checkout release", repo.workDir);
+      await addCommit(
+        repo.workDir,
+        "feature.txt",
+        "header\nline1\nline2  \nline3  \nfooter\n",
+        "Add trailing whitespace to feature.txt on release",
+      );
+      await gitCmd("push origin release", repo.workDir);
+
+      // With default cherry-pick, this exits 0 but silently duplicates
+      // line2/line3 — the assertion below catches the wrong content.
+      await git.cherryPick([featureSha], "fail", repo.workDir);
+
+      const content = await readFile(
+        join(repo.workDir, "feature.txt"),
+        "utf-8",
+      );
+      // Each line should appear exactly once; no duplication.
+      ctx
+        .expect(content)
+        .toBe("header\nline1\nline2\nline_new\nline3\nfooter\n");
     },
   );
 });

--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -625,21 +625,17 @@ describe("cherry-pick whitespace-tolerant mode", () => {
   }
 
   it.concurrent(
-    // This test documents the #529 bug class: repos that declare
+    // This test proves the fix for the #529 bug class: repos that declare
     // `merge=union` for a path — the common Visual Studio convention for
     // `.csproj`/`.sln` files — get silent content duplication when the
     // target branch's context lines differ from the source parent only by
-    // trailing whitespace. Without a custom merge driver, this kind of
-    // divergence produces an explicit conflict; the union driver instead
-    // combines both sides of the unaligned hunk, so it keeps both the target
-    // branch's version of line2/line3 and the source's inserted content —
-    // the cherry-pick exits 0 with line2/line3 doubled in the file.
+    // trailing whitespace, because the union merge driver combines both
+    // sides of a hunk it can't align instead of flagging a conflict.
     //
-    // This test fails red today because the resulting file content has
-    // those lines doubled. It goes green when whitespace-tolerant mode is
-    // wired in (Step 2), since -Xignore-space-at-eol lets the merge ignore
-    // the trailing-whitespace difference and align cleanly up front.
-    "default mode fails when context lines differ only by trailing whitespace (reproducer)",
+    // With whitespace_tolerant mode (-Xignore-space-at-eol), the cherry-pick
+    // applies cleanly: the merge ignores the trailing-whitespace difference
+    // and aligns up front, so the union driver never has to guess.
+    "whitespace_tolerant mode applies cleanly when context lines differ only by trailing whitespace",
     async (ctx) => {
       const repo = (ctx.repo = await template.createTestRepo());
       const git = setupGit();
@@ -691,9 +687,15 @@ describe("cherry-pick whitespace-tolerant mode", () => {
       );
       await gitCmd("push origin release", repo.workDir);
 
-      // With default cherry-pick, this exits 0 but silently duplicates
-      // line2/line3 — the assertion below catches the wrong content.
-      await git.cherryPick([featureSha], "fail", repo.workDir, "default");
+      // With whitespace_tolerant mode (-Xignore-space-at-eol) the cherry-pick
+      // applies cleanly: trailing whitespace differences in context lines are
+      // ignored, line_new is inserted cleanly, and no duplication occurs.
+      await git.cherryPick(
+        [featureSha],
+        "fail",
+        repo.workDir,
+        "whitespace_tolerant",
+      );
 
       const content = await readFile(
         join(repo.workDir, "feature.txt"),

--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -693,7 +693,7 @@ describe("cherry-pick whitespace-tolerant mode", () => {
 
       // With default cherry-pick, this exits 0 but silently duplicates
       // line2/line3 — the assertion below catches the wrong content.
-      await git.cherryPick([featureSha], "fail", repo.workDir);
+      await git.cherryPick([featureSha], "fail", repo.workDir, "default");
 
       const content = await readFile(
         join(repo.workDir, "feature.txt"),

--- a/src/test/git.test.ts
+++ b/src/test/git.test.ts
@@ -1,21 +1,23 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let response = { exitCode: 0, stdout: "" };
 let responseCommit = { exitCode: 0, stdout: "" };
 
-vi.mock("@actions/exec", () => ({
-  getExecOutput: vi.fn(
-    (command: string, args?: readonly string[] | undefined) => {
-      if (command === "git" && args) {
-        const subCommand = args[0];
-        if (subCommand === "commit") {
-          // Mock behavior for "git commit"
-          return responseCommit;
-        }
+const getExecOutputMock = vi.fn(
+  (command: string, args?: readonly string[] | undefined) => {
+    if (command === "git" && args) {
+      const subCommand = args[0];
+      if (subCommand === "commit") {
+        // Mock behavior for "git commit"
+        return responseCommit;
       }
-      return response;
-    },
-  ),
+    }
+    return response;
+  },
+);
+
+vi.mock("@actions/exec", () => ({
+  getExecOutput: getExecOutputMock,
 }));
 
 const { Git, GitRefNotFoundError } = await import("../git.js");
@@ -57,7 +59,9 @@ describe("git.cherryPick", () => {
     describe("throws Error", () => {
       it("when failing with an unexpected non-zero exit code", async () => {
         response.exitCode = 1;
-        await expect(git.cherryPick(["unknown"], `fail`, "")).rejects.toThrow(
+        await expect(
+          git.cherryPick(["unknown"], `fail`, "", "default"),
+        ).rejects.toThrow(
           `'git cherry-pick -x unknown' failed with exit code 1`,
         );
       });
@@ -67,7 +71,7 @@ describe("git.cherryPick", () => {
       it("when success", async () => {
         response.exitCode = 0;
         await expect(
-          git.cherryPick(["unknown"], `draft_commit_conflicts`, ""),
+          git.cherryPick(["unknown"], `draft_commit_conflicts`, "", "default"),
         ).resolves.toBe(null);
       });
     });
@@ -78,7 +82,7 @@ describe("git.cherryPick", () => {
       it("when failing with an unexpected non-zero and non-one exit code", async () => {
         response.exitCode = 128;
         await expect(
-          git.cherryPick(["unknown"], `draft_commit_conflicts`, ""),
+          git.cherryPick(["unknown"], `draft_commit_conflicts`, "", "default"),
         ).rejects.toThrow(
           `'git cherry-pick -x unknown' failed with exit code 128`,
         );
@@ -88,7 +92,7 @@ describe("git.cherryPick", () => {
         response.exitCode = 1;
         responseCommit.exitCode = 1;
         await expect(
-          git.cherryPick(["unknown"], `draft_commit_conflicts`, ""),
+          git.cherryPick(["unknown"], `draft_commit_conflicts`, "", "default"),
         ).rejects.toThrow(
           `'git cherry-pick -x unknown' failed with exit code 1`,
         );
@@ -99,7 +103,12 @@ describe("git.cherryPick", () => {
           response.exitCode = 1;
           responseCommit.exitCode = 0;
           await expect(
-            git.cherryPick(["unknown"], `draft_commit_conflicts`, ""),
+            git.cherryPick(
+              ["unknown"],
+              `draft_commit_conflicts`,
+              "",
+              "default",
+            ),
           ).resolves.toEqual(["unknown"]);
         });
       });
@@ -108,10 +117,78 @@ describe("git.cherryPick", () => {
         it("when success", async () => {
           response.exitCode = 0;
           await expect(
-            git.cherryPick(["unknown"], `draft_commit_conflicts`, ""),
+            git.cherryPick(
+              ["unknown"],
+              `draft_commit_conflicts`,
+              "",
+              "default",
+            ),
           ).resolves.toBe(null);
         });
       });
+    });
+  });
+});
+
+describe("git.cherryPick mergeMode arg contract", () => {
+  beforeEach(() => {
+    response.exitCode = 0;
+    responseCommit.exitCode = 0;
+    getExecOutputMock.mockClear();
+  });
+
+  describe("fail mode (conflict_resolution: fail)", () => {
+    it("default mode passes no extra flags", async () => {
+      await git.cherryPick(["abc123"], "fail", "", "default");
+      const cherryPickCall = getExecOutputMock.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",
+      );
+      expect(cherryPickCall).toBeDefined();
+      expect(cherryPickCall![1]).toEqual(["cherry-pick", "-x", "abc123"]);
+    });
+
+    it("whitespace_tolerant mode adds -Xignore-space-at-eol", async () => {
+      await git.cherryPick(["abc123"], "fail", "", "whitespace_tolerant");
+      const cherryPickCall = getExecOutputMock.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",
+      );
+      expect(cherryPickCall).toBeDefined();
+      expect(cherryPickCall![1]).toEqual([
+        "cherry-pick",
+        "-x",
+        "-Xignore-space-at-eol",
+        "abc123",
+      ]);
+    });
+  });
+
+  describe("draft mode (conflict_resolution: draft_commit_conflicts)", () => {
+    it("default mode passes no extra flags", async () => {
+      await git.cherryPick(["abc123"], "draft_commit_conflicts", "", "default");
+      const cherryPickCall = getExecOutputMock.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",
+      );
+      expect(cherryPickCall).toBeDefined();
+      expect(cherryPickCall![1]).toEqual(["cherry-pick", "-x", "abc123"]);
+    });
+
+    it("whitespace_tolerant mode adds -Xignore-space-at-eol", async () => {
+      await git.cherryPick(
+        ["abc123"],
+        "draft_commit_conflicts",
+        "",
+        "whitespace_tolerant",
+      );
+      const cherryPickCall = getExecOutputMock.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",
+      );
+      expect(cherryPickCall).toBeDefined();
+      expect(cherryPickCall![1]).toEqual([
+        "cherry-pick",
+        "-x",
+        "-Xignore-space-at-eol",
+        "abc123",
+      ]);
     });
   });
 });

--- a/src/test/helpers/config.ts
+++ b/src/test/helpers/config.ts
@@ -12,7 +12,11 @@ export function makeConfig(overrides?: Partial<Config>): Config {
     add_labels: [],
     add_reviewers: [],
     add_team_reviewers: [],
-    commits: { cherry_picking: "auto", merge_commits: "fail" },
+    commits: {
+      cherry_picking: "auto",
+      cherry_picking_merge_mode: "default",
+      merge_commits: "fail",
+    },
     copy_milestone: false,
     copy_assignees: false,
     copy_requested_reviewers: false,

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import dedent from "dedent";
-import { getMentionedIssueRefs, replacePlaceholders } from "../utils.js";
+import {
+  coerceCherryPickingMergeMode,
+  getMentionedIssueRefs,
+  replacePlaceholders,
+} from "../utils.js";
 
 describe("get mentioned issues", () => {
   describe("returns an empty list", () => {
@@ -241,6 +245,32 @@ describe("compose body/title", () => {
         "Backport of pull made by @foo-author",
       );
     });
+  });
+});
+
+describe("coerceCherryPickingMergeMode", () => {
+  it('coerces empty string to "default"', () => {
+    expect(coerceCherryPickingMergeMode("")).toEqual("default");
+  });
+
+  it('passes through "default"', () => {
+    expect(coerceCherryPickingMergeMode("default")).toEqual("default");
+  });
+
+  it('passes through "whitespace_tolerant"', () => {
+    expect(coerceCherryPickingMergeMode("whitespace_tolerant")).toEqual(
+      "whitespace_tolerant",
+    );
+  });
+
+  it('returns "invalid" for an unrecognized value', () => {
+    expect(coerceCherryPickingMergeMode("invalid_value")).toEqual("invalid");
+  });
+
+  it('returns "invalid" for wrong case (case-sensitive)', () => {
+    expect(coerceCherryPickingMergeMode("WHITESPACE_TOLERANT")).toEqual(
+      "invalid",
+    );
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,16 @@ const patterns = {
   ref: /(?:^| )((?<org>[^\n #\/]+)\/(?<repo>[^\n #\/]+))?#(?<number>[1-9][0-9]*)(?: |$)/gm,
 };
 
+export function coerceCherryPickingMergeMode(
+  raw: string,
+): "default" | "whitespace_tolerant" | "invalid" {
+  const value = raw === "" ? "default" : raw;
+  if (value === "default" || value === "whitespace_tolerant") {
+    return value;
+  }
+  return "invalid";
+}
+
 const toRef = (url: string) => {
   // matchAll is not yet available to directly access the captured groups of all matches
   // so this maps the urls to GitHub refs by matching again without the global flag


### PR DESCRIPTION
## Summary

Backport-action's main job is to cherry-pick commits. Cherry-picking can fail with a conflict when the target branch's content differs from the source only by trailing whitespace, even when nothing meaningful has changed. This is easy to hit in practice: a different editor/formatter config, a one-off whitespace cleanup, line-ending normalization, etc. This PR adds an opt-in `cherry_picking_merge_mode` input; set it to `whitespace_tolerant` and git ignores trailing-whitespace-only differences when matching context lines, so these cherry-picks apply cleanly instead of conflicting.

- New input: `cherry_picking_merge_mode`, values `default` (unchanged behavior) | `whitespace_tolerant`.
- `whitespace_tolerant` passes `-Xignore-space-at-eol` to `git cherry-pick`.
- Default behavior is byte-for-byte unchanged, so this is opt-in only.

Fixes #529.

## The #529 bug case

In most repos, the whitespace divergence above just causes a conflict — annoying, but visible, and you fix it by hand. In repos whose `.gitattributes` sets `merge=union` for the affected file type (a common Visual Studio convention for `.csproj`/`.sln`), it's worse: git's `union` merge driver combines both sides of the hunk it couldn't align *instead of* flagging a conflict, so the cherry-pick succeeds with the content **silently duplicated** — no conflict, no warning. `whitespace_tolerant` mode fixes this the same way it fixes the general case: by ignoring the whitespace difference up front, so the merge aligns cleanly and the union driver never has to guess.

<details>
<summary>Further reading, and whether to also drop <code>merge=union</code>in your repo</summary>

`git cherry-pick` is a 3-way merge: the picked commit's parent (base), your current branch (ours), and the picked commit (theirs). Git compares the context (the lines around the changes) to determine exactly how to merge them. A context line that differs between base and ours *only* by trailing whitespace breaks that alignment regardless of `merge=union` — the merge driver just determines what happens next.

`merge=union`'s silent-duplication risk isn't new or Visual-Studio-specific:

- [git's `gitattributes` docs](https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-union) warn that union "tends to leave the added lines in the resulting file in random order" and to not use it without understanding the implications.
- [Phil Haack, "Merge conflicts in csproj files" (2014)](https://haacked.com/archive/2014/04/16/csproj-merge-conflicts/) — GitHub for Windows shipped `merge=union` for `.csproj` by default, then reversed it after finding it silently corrupts files instead of conflicting.
- [`gitattributes/gitattributes` issue #21](https://github.com/gitattributes/gitattributes/issues/21) — the community `.gitattributes` template repo discussing removing `merge=union` from the Visual Studio template for the same reason.

If your repo has `merge=union` and doesn't specifically need it, removing it is worth considering. It mainly exists to reduce conflict noise on auto-generated project-file edits. Dropping it trades that for never risking silent corruption. `whitespace_tolerant` mode is the narrower fix: it only targets the whitespace case, without giving up `merge=union`'s broader conflict-reduction for everything else.

</details>

## Test plan
- [x] New integration test reproduces the silent duplication (`merge=union` + trailing whitespace) and proves `whitespace_tolerant` mode fixes it