### PR TITLE
Introduce grill me with docs

### DIFF
--- a/.claude/skills/grill-me-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/grill-me-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.claude/skills/grill-me-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-me-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A concise description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/grill-me-with-docs/LICENSE
+++ b/.claude/skills/grill-me-with-docs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/grill-me-with-docs/SKILL.md
+++ b/.claude/skills/grill-me-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-me-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,61 @@
+# Backport action
+
+A GitHub Action that backports merged pull requests to other branches by cherry-picking their commits onto target branches and opening pull requests with the result.
+
+## Language
+
+**Original pull request**:
+The pull request being backported. Identified from the workflow event payload, or from the `source_pr_number` input when set. Must be merged.
+_Avoid_: source PR, merged PR (use only when merge-state is the actual point)
+
+**Backport pull request**:
+The pull request the action creates on a target branch, containing the cherry-picked commits.
+
+**Target branch**:
+A branch to which the original pull request is backported. Selected by backport labels and/or the `target_branches` input. Lives in the target repository.
+
+**Target repository**:
+The repository where the backport pull request is created. Defaults to the workflow's repository; can be overridden via the experimental `downstream_repo`/`downstream_owner` (likely renamed when promoted out of experimental).
+_Avoid_: downstream repo (the existing input name is a frozen historical artifact)
+
+**Backport label**:
+A label on the original pull request matching the `label_pattern` input, whose capture group names a target branch. Other labels used in workflow logic (e.g. `backport-auto-merge`) are not backport labels — they're not recognised by the action as a category.
+
+**Commits to backport**:
+The set of commits selected from the original pull request's history and passed to `git cherry-pick`. Governed by the `cherry_picking` input and, when set to `auto`, by the original pull request's merge method.
+
+**Cherry-picked commits**:
+The new commits created on the target branch by `git cherry-pick`. The commit author is preserved from the input commits; the commit committer is overwritten by `git_committer_name` / `git_committer_email` (defaulting to `github-actions[bot]`). Each carries an `-x` trailer referencing the input commit as audit trail.
+
+**Merge method**:
+How a pull request is merged on GitHub. One of: squash-and-merge, rebase-and-merge, or merge commit. The action *observes* the original pull request's merge method (consumed by `cherry_picking: auto`) and *configures* the backport pull request's merge method (via `auto_merge_method`). Always disambiguate which pull request's merge method is meant.
+
+**PR author**:
+The GitHub user who opened a pull request. The action can copy the original PR author to the backport PR as assignee or reviewer (`add_author_as_assignee`, `add_author_as_reviewer`, `pull_author` placeholder).
+_Avoid_: just "author" (collides with commit author)
+
+**Commit author** / **commit committer**:
+Git commit metadata. Cherry-picking preserves the commit author and overwrites the commit committer. Always pair "commit" with the word.
+
+## Relationships
+
+- An **original pull request** produces zero or more **backport pull requests**, one per attempted **target branch**.
+- A **backport pull request** lives on a **target branch** inside the **target repository**.
+- A **backport label** on the **original pull request** selects one **target branch**.
+- The **commits to backport** (input to cherry-pick) become **cherry-picked commits** (output, on the target branch) after `git cherry-pick`.
+- The **original pull request's** **merge method** determines which **commits to backport** are selected when `cherry_picking: auto`.
+
+## Example dialogue
+
+> **Dev:** "If the **original pull request** was merged via squash-and-merge, what are the **commits to backport**?"
+> **Maintainer:** "Just the squashed commit on the base branch. The **cherry-picked commit** on the **target branch** keeps the squash author but gets `github-actions[bot]` as the **commit committer** unless overridden."
+> **Dev:** "And the **PR author** — that's a different person from the **commit author**?"
+> **Maintainer:** "Usually the same, but conceptually separate. **PR author** is the GitHub user who opened the PR; **commit author** is git metadata on each commit."
+
+## Flagged ambiguities
+
+- "Source PR" vs "original PR" vs "merged PR" — resolved to **original pull request**. `source_pr_number` keeps its name (frozen API) but its description refers to the original pull request.
+- "Downstream repo" — resolved to **target repository** in prose. Input names `downstream_repo`/`downstream_owner` are experimental and likely renamed on promotion.
+- "Merge commit" was overloaded across: a merge method, an intermediate commit in PR history (`merge_commits` input), and the result of auto-merge. Resolved by always pairing with context; no coined term for the intermediate case.
+- "Author" was used for three concepts: PR author, commit author, commit committer. Resolved by always qualifying ("PR author" / "commit author" / "commit committer").
+- "Successful" / "failed" / "skipped" / "attempted" — intentionally *not* glossarised. The output `was_successful` is documented precisely in `README.md`; surrounding adjectives are plain English.


### PR DESCRIPTION
This pull request introduces comprehensive documentation by introducing the "grill-me-with-docs" skill, establishing clear standards for domain modeling, terminology, and architectural decision records (ADRs). It also adds a project-specific `CONTEXT.md` that defines key terms and their relationships for the backport action.

**Skill Documentation and Standards**

* Added `.claude/skills/grill-me-with-docs/SKILL.md` describing the purpose, workflow, and best practices for the "grill-me-with-docs" skill, including how to challenge plans against the domain model, sharpen terminology, and update documentation inline.
* Introduced `.claude/skills/grill-me-with-docs/CONTEXT-FORMAT.md` specifying the required structure, rules, and usage for `CONTEXT.md` and `CONTEXT-MAP.md` domain glossaries.
* Added `.claude/skills/grill-me-with-docs/ADR-FORMAT.md` detailing the format, numbering, and criteria for writing ADRs, emphasizing minimalism and clarity.

**Project Domain Glossary**

* Created `CONTEXT.md` at the repo root, defining essential terms, relationships, and disambiguations for the backport action, following the new context format.

**Licensing**

* Added `MIT License` in `.claude/skills/grill-me-with-docs/LICENSE` for the skill documentation.