### PR TITLE
Automate release note generation and draft release creation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,11 +1,15 @@
 changelog:
   categories:
+    - title: What's Changed
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+          - maintenance
     - title: Updated dependencies
       labels:
         - dependencies
     - title: Maintenance changes
       labels:
         - maintenance
-    - title: What's Changed
-      labels:
-        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Updated dependencies
+      labels:
+        - dependencies
+    - title: Maintenance changes
+      labels:
+        - maintenance
+    - title: What's Changed
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   categories:
-    - title: What's Changed
+    - title: What's changed
       labels:
         - "*"
       exclude:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     "helpers:pinGitHubActionDigestsToSemver",
     ":semanticCommitsDisabled"
   ],
+  "addLabels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest", "lockFileMaintenance"],

--- a/.github/workflows/pr-info.yml
+++ b/.github/workflows/pr-info.yml
@@ -19,7 +19,7 @@ jobs:
             const isAutoMerge = labels.includes('automerge') && author === 'renovate[bot]';
             const message = isAutoMerge
               ? 'This PR will be merged automatically once the build check passes.'
-              : 'This PR can be added to the merge queue by commenting `@mergifyio queue`.';
+              : 'This PR can be added to the merge queue by commenting `@mergifyio queue`.\n\nIf this PR is a maintenance change (CI, tooling, internal refactor) rather than a user-visible change, please add the `maintenance` label.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,12 @@ jobs:
 
       - name: Print next development version commit
         run: git show ${{ steps.commit-next-dev.outputs.commit_sha }} | cat
+
+      - name: Create draft release
+        if: ${{ inputs.dryRun == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create v${{ inputs.releaseVersion }} \
+            --draft \
+            --generate-notes


### PR DESCRIPTION
## Summary

- Add `.github/release.yml` to configure GitHub's release notes generator with three categories: **Updated dependencies** (`dependencies` label), **Maintenance changes** (`maintenance` label), and **What's Changed** (catch-all)
- Add `dependencies` label unconditionally to all Renovate PRs via top-level `addLabels` in `renovate.json`, so dependency updates don't land in "What's Changed"
- Add a **Create draft release** step at the end of the Release workflow that calls `gh release create --draft --generate-notes`; skipped on dry runs
- Extend the PR info comment for non-Renovate PRs to remind contributors to add the `maintenance` label for non-user-visible changes (CI, tooling, internal refactors)

## Test plan

- [ ] Verify `.github/release.yml` renders expected sections on the next release's auto-generated notes
- [ ] Open a test Renovate PR and confirm it receives the `dependencies` label
- [ ] Run the Release workflow with `dryRun: true` and confirm the draft release step is skipped
- [ ] Run the Release workflow with `dryRun: false` (on a test tag) and confirm a draft release appears in the GitHub Releases page with generated notes
- [ ] Open a non-Renovate PR and confirm the posted comment includes the `maintenance` label reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)