### PR TITLE
Substitute placeholders in a single pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,11 @@ Preserve when making changes:
 
 ## Don't break user space
 
-Any behavioral change a user didn't explicitly configure is forbidden. This includes action `inputs`/`outputs`, the workflow events the action runs on, and assumptions about the environment (e.g. the checked-out git repository).
+Action `inputs`/`outputs`, the workflow events the action runs on, and assumptions about the environment (e.g. the checked-out git repository) break only in a major version.
+
+Behavior may also break in a minor or patch, but only when the old behavior was **unusable** (the run failed or the operation did not complete), **unstable** (nondeterministic), or **unobservable**. Otherwise it is breaking however wrong the old behavior was — "nobody could legitimately depend on that" is not the test; a user who worked around the bug is a real dependent.
+
+Majors are allowed (v0–v4) and are the normal way to ship a breaking change. Prefer one over a config option, which costs two code paths and docs forever; add an option only when both behaviors have a real constituency (e.g. `cherry_picking_merge_mode`).
 
 ## Maintainability
 

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -352,6 +352,29 @@ describe("Backport.run() orchestration", () => {
         expect.objectContaining({ title: "[Backport main] Test PR" }),
       );
     });
+
+    it("repeated placeholders: replaces every occurrence", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit();
+      const config = makeConfig({
+        pull: {
+          title: "${target_branch}: backport to ${target_branch}",
+          description: "Backport of #${pull_number} (see #${pull_number})",
+          branch_name:
+            "${target_branch}/backport-${pull_number}-to-${target_branch}",
+        },
+      });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs[0]).toEqual(
+        expect.objectContaining({
+          title: "main: backport to main",
+          body: "Backport of #42 (see #42)",
+          head: "main/backport-42-to-main",
+        }),
+      );
+    });
   });
 
   describe("assignees", () => {

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -293,6 +293,56 @@ describe("compose body/title", () => {
         ).toEqual("Refers to #123 and again #123");
       });
     });
+
+    describe("inserts placeholder values verbatim", () => {
+      it("does not corrupt a body containing $$ (whole-match token)", () => {
+        const template = "${pull_description}";
+        const body = "Run `echo $$ > app.pid` to reproduce.";
+        expect(
+          replacePlaceholders(template, { ...main_default, body }, target),
+        ).toEqual(body);
+      });
+
+      it("does not corrupt a body containing $& (matched-substring token)", () => {
+        const template = "${pull_description}";
+        const body = "Replace with `sed 's/x/$&/'`.";
+        expect(
+          replacePlaceholders(template, { ...main_default, body }, target),
+        ).toEqual(body);
+      });
+
+      it("does not corrupt a body containing $` (preceding-portion token)", () => {
+        const template = "Backport:\n${pull_description}";
+        const body = "Costs $`5` per run.";
+        expect(
+          replacePlaceholders(template, { ...main_default, body }, target),
+        ).toEqual("Backport:\nCosts $`5` per run.");
+      });
+
+      it("does not corrupt a body containing $' (following-portion token)", () => {
+        const template = "${pull_description}";
+        const body = "Use `printf $'a\nb'` instead.";
+        expect(
+          replacePlaceholders(template, { ...main_default, body }, target),
+        ).toEqual(body);
+      });
+
+      it("does not corrupt a body containing $1 (capture group token)", () => {
+        const template = "${pull_description}";
+        const body = "Pass `$1` through.";
+        expect(
+          replacePlaceholders(template, { ...main_default, body }, target),
+        ).toEqual(body);
+      });
+
+      it("does not expand placeholders inside inserted content", () => {
+        const template = "${pull_description}";
+        const body = "Target is ${target_branch}";
+        expect(
+          replacePlaceholders(template, { ...main_default, body }, target),
+        ).toEqual("Target is ${target_branch}");
+      });
+    });
   });
 });
 

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -245,6 +245,54 @@ describe("compose body/title", () => {
         "Backport of pull made by @foo-author",
       );
     });
+
+    describe("for a template that repeats a placeholder", () => {
+      it("with pull_author placeholder", () => {
+        const template = "Backported by @${pull_author}, cc @${pull_author}";
+        expect(replacePlaceholders(template, main_default, target)).toEqual(
+          "Backported by @foo-author, cc @foo-author",
+        );
+      });
+
+      it("with pull_number placeholder", () => {
+        const template = "Backport of #${pull_number} (see #${pull_number})";
+        expect(replacePlaceholders(template, main_default, target)).toEqual(
+          "Backport of #123 (see #123)",
+        );
+      });
+
+      it("with pull_title placeholder", () => {
+        const template = "${pull_title} (backport of ${pull_title})";
+        expect(replacePlaceholders(template, main_default, target)).toEqual(
+          "some pr title (backport of some pr title)",
+        );
+      });
+
+      it("with pull_description placeholder", () => {
+        const template = "${pull_description} -- repeated: ${pull_description}";
+        expect(replacePlaceholders(template, main_default, target)).toEqual(
+          "foo-body -- repeated: foo-body",
+        );
+      });
+
+      it("with target_branch placeholder", () => {
+        const template = "${target_branch}: backport to ${target_branch}";
+        expect(replacePlaceholders(template, main_default, target)).toEqual(
+          "foo-target: backport to foo-target",
+        );
+      });
+
+      it("with issue_refs placeholder", () => {
+        const template = "Refers to ${issue_refs} and again ${issue_refs}";
+        expect(
+          replacePlaceholders(
+            template,
+            { ...main_default, body: "Body mentions #123 and that's it." },
+            target,
+          ),
+        ).toEqual("Refers to #123 and again #123");
+      });
+    });
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,12 +13,12 @@ export function replacePlaceholders(
 ): string {
   const issues = getMentionedIssueRefs(main.body);
   return template
-    .replace("${pull_author}", main.user.login)
-    .replace("${pull_number}", main.number.toString())
-    .replace("${pull_title}", main.title)
-    .replace("${pull_description}", main.body ?? "")
-    .replace("${target_branch}", target)
-    .replace("${issue_refs}", issues.join(" "));
+    .replaceAll("${pull_author}", main.user.login)
+    .replaceAll("${pull_number}", main.number.toString())
+    .replaceAll("${pull_title}", main.title)
+    .replaceAll("${pull_description}", main.body ?? "")
+    .replaceAll("${target_branch}", target)
+    .replaceAll("${issue_refs}", issues.join(" "));
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,14 +11,17 @@ export function replacePlaceholders(
   main: Pick<PullRequest, "body" | "user" | "number" | "title">,
   target: string,
 ): string {
-  const issues = getMentionedIssueRefs(main.body);
-  return template
-    .replaceAll("${pull_author}", main.user.login)
-    .replaceAll("${pull_number}", main.number.toString())
-    .replaceAll("${pull_title}", main.title)
-    .replaceAll("${pull_description}", main.body ?? "")
-    .replaceAll("${target_branch}", target)
-    .replaceAll("${issue_refs}", issues.join(" "));
+  const values: Record<string, string> = {
+    pull_author: main.user.login,
+    pull_number: main.number.toString(),
+    pull_title: main.title,
+    pull_description: main.body ?? "",
+    target_branch: target,
+    issue_refs: getMentionedIssueRefs(main.body).join(" "),
+  };
+  return template.replace(/\$\{(\w+)\}/g, (match, name) =>
+    Object.hasOwn(values, name) ? values[name] : match,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Two fixes to how placeholders are substituted into backport pull request titles, descriptions, and branch names.

**You can now repeat a placeholder** — every occurrence is replaced, not just the first:

```yaml
pull_description: |
  Backport of #${pull_number} to `${target_branch}`.

  Original discussion: #${pull_number}
```

> Backport of #1234 to `release-1.2`.
>
> Original discussion: #1234

**And `$` characters written by the original author now survive intact.** A description containing a shell snippet like `` `echo $$ > app.pid` `` was silently rewritten to `` `echo $ > app.pid` ``, turning a documented command into a wrong one. `$$`, `$&`, `` $` `` and `$'` were all affected — `` $` `` didn't just drop characters, it spliced a duplicate of the template preamble into the middle of the body.

Fixes #435.
Fixes #694.

## Breaking changes

All three are behavior changes for users who configured nothing, so this belongs in a major release. Each is independent — most users will be affected by none of them:

1. A repeated placeholder is substituted at **every** occurrence. Previously only the first.
2. `$` sequences in a pull request description or title are inserted **verbatim**. Previously interpreted — so anyone who worked around the corruption by doubling `$$` into `$$$$` will now see `$$$$`.
3. A placeholder written **inside** an inserted value is no longer expanded. The substitutions used to be chained, so a `${target_branch}` appearing in the source pull request's own description was replaced by a later pass.

## For reviewers

`replacePlaceholders` chained six `.replace`/`.replaceAll` calls, each with a *string* replacement. It is now a single pass over the template with a `/g` regex and a *function* replacement. All three fixes fall out of that one change:

- a function replacement disables JavaScript's `$` handling → 2
- `/g` replaces every occurrence by construction → 1, which makes the intermediate `replaceAll` step redundant
- a single pass never re-scans inserted content → 3

Unknown placeholders still pass through unchanged.

Commits are in TDD order — a failing test then its fix, for each issue in turn. `CLAUDE.md` also gains the rule this work forced us to pin down: which changes may ship in a patch and which need a major, and why a config option isn't the answer here.

## Test plan

- [x] `npm run all` green
- [x] Integration test covers all three placeholder-bearing inputs (`pull_title`, `pull_description`, `branch_name`), each failing before the fix
- [x] Unit test per supported placeholder, each repeating that placeholder
- [x] Unit test per affected `$` sequence, plus `$1` as a regression guard
- [x] Unit test pinning that placeholders inside inserted content are not expanded
- [x] No `dist/` in the diff
